### PR TITLE
adding bundle for for ease of deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # kruize-operator
-// TODO(user): Add simple overview of use/purpose
+The kruize operator allows for easy deployment of the kruize project on both minikube and openshift. 
 
 ## Description
-// TODO(user): An in-depth paragraph about your project and overview of use
+Deploying the kruize operator will allow you to adjust varius options for your project where kruize is deployed. For an example of running kruize and the operator see https://github.com/kruize/kruize-demos. You can change the YAML file (found in samples) to deploy with whatever options you wish. 
+
+If you wish to run the prepackaged bundle you will require both the latest version of the operator-sdk and olm. You can then use operator-sdk run bundle <bundle image> to deploy it. 
 
 ## Getting Started
 


### PR DESCRIPTION
Adding the bundle files and the bundle.Dockerfile. This provides all the information OLM needs to spin up instances of the operator. Bundling the operator lets OLM provide the operator as a catalogue and then can be deployed through OLM. The bundle dockerfiles and csv provide the information it needs to be able to create the catalogue as well as the manifest and image.