### PR TITLE
Resolve kruize-ui service naming issue

### DIFF
--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -637,14 +637,14 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: kruize-ui-service  # Changed from kruize-ui-nginx-service to kruize-ui-service
+  name: kruize-ui-nginx-service  # Changed back to kruize-ui-nginx-service
   namespace: %s
   labels:
-    app: kruize-ui  # Changed from kruize-ui-nginx to kruize-ui
+    app: kruize-ui-nginx  # Changed back to kruize-ui-nginx
 spec:
   to:
     kind: Service
-    name: kruize-ui-service  # Changed from kruize-ui-nginx to kruize-ui-service
+    name: kruize-ui-nginx-service  # Changed from kruize-ui-service to kruize-ui-nginx-service
     weight: 100
   port:
     targetPort: http
@@ -880,7 +880,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kruize-ui-service
+  name: kruize-ui-nginx-service
   namespace: %s
 spec:
   selector:


### PR DESCRIPTION
kruize-ui service changed from kruize-ui to kruize-ui-nginx as in current kruize repo