### PR TITLE
Modify Hibernate Schema creation mode

### DIFF
--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -510,7 +510,7 @@ data:
         "c3p0maxsize": 10,
         "c3p0timeout": 300,
         "c3p0maxstatements": 100,
-        "hbm2ddlauto": "update",
+        "hbm2ddlauto": "none",
         "showsql": "false",
         "timezone": "UTC"
       },


### PR DESCRIPTION
This PR contains a minor fix for the missing partition issue while running kruize-demos.

Modified the `hbmddlauto` value to `none`  so that the code reads the DDL statements from the migration DDL file instead of getting auto created based on java entity.