### PR TITLE
Use explicit rewrite for NGINX API proxy

### DIFF
--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -680,8 +680,9 @@ data:
             index index.html;
             
             # API proxy to Kruize backend
-            location /api/ {
-                proxy_pass http://kruize_backend/;
+            location ^~ /api/ {
+                rewrite ^/api(.*)$ $1 break;
+                proxy_pass http://kruize_backend;
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -689,6 +690,7 @@ data:
                 proxy_connect_timeout 30s;
                 proxy_send_timeout 30s;
                 proxy_read_timeout 30s;
+
             }
             
             # Proxy health check


### PR DESCRIPTION
This PR fixes API proxy to use explicit rewrite, fixing the blank UI on clicking the `Import Metadata` button.