### PR TITLE
Use specific image tags for kruize-ui and autotune images

### DIFF
--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -555,7 +555,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: kruize
-        image: quay.io/kruize/autotune_operator:latest
+        image: quay.io/kruize/autotune_operator:0.7
         ports:
         - containerPort: 8080
         env:

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -743,7 +743,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: kruize-ui-nginx
-        image: quay.io/kruize/kruize-ui:latest
+        image: quay.io/kruize/kruize-ui:0.0.9
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
This PR has the following changes:
- updates the `kruize-ui`build tag, replacing `latest` with `0.0.9` as per the quay repository.
- updates the `autotune_operator` build tag, replacing `latest` with `0.7`, following the latest release

https://quay.io/repository/kruize/kruize-ui?tab=tags 

<img width="1920" height="467" alt="image" src="https://github.com/user-attachments/assets/e8c6530f-2f08-4ab5-988f-9a8bbdfac0cd" />
