### PR TITLE
Refactor Operator RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -129,10 +129,7 @@ rules:
   - verticalpodautoscalers
   verbs:
   - create
-  - delete
   - get
-  - patch
-  - update
 - apiGroups:
   - batch
   resources:

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -92,7 +92,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;
 //+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes,verbs=get;
-//+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;create;update;patch;delete
+//+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;create;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This PR refactors operator RBAC permissions:

1. Removes `update, delete and patch` for resources:

> secrets, deployments, cronjobs, jobs, storageclass ,ingress, servicemonitors,prometheuses, statefulsets, deamonsets, role, rolebindings, verticalpodautoscalers

2. Removes `list and watch` permissions for resources: 

> verticalpodautoscalers, nodes, endpoints, prometheuses, alertmanager, deployment, statefulset, cronjob, deamonset, customresourcedefinitions, securitycontextconstraints, ingresses, servicemonitors, storageclasses, rolebindings, roles, clusterroles, jobs, cronjobs, statefulsets, secrets 

These permissions are currently not required or used by Operator. Will be rolled back once Kruize operator supports upgrades and full lifecycle management.

Docker image - `quay.io/shbirada/kruize-operator:reduce_rbac_permissions` or `quay.io/shbirada/kruize-operator:pr_25`