### PR TITLE
Fix Operator RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,8 @@ rules:
   - endpoints
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -41,6 +43,8 @@ rules:
   - nodes
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -107,6 +111,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -123,6 +129,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - autoscaling.k8s.io
   resources:
@@ -130,6 +138,10 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -151,12 +163,15 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - metrics.k8s.io
   resources:
   - nodes
   verbs:
   - get
+  - list
 - apiGroups:
   - metrics.k8s.io
   resources:
@@ -173,6 +188,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -180,6 +197,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -187,6 +206,7 @@ rules:
   verbs:
   - create
   - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -201,6 +221,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - my.domain
   resources:
@@ -231,6 +253,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -247,6 +271,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -254,6 +280,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -69,30 +69,30 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;create
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;create
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
-//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;create
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;create
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;create;use
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;create
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create
-//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;create
+//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;create
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;create
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=get;create
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create;update
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;create
-//+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;
+//+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes,verbs=get;
-//+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;create;
+//+kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes,verbs=get;list;
+//+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
With current set of RBAC permissions, the operator image -  `quay.io/dinogun210/kruize-operator:0.0.2-rc1` throws reconciliation errors hence restoring some of the permissions - 

Current reconciliation error logged in operator pods - 
```
Deploying Kruize for cluster type: openshift
2025-11-10T05:40:23Z	INFO	Creating new cluster-scoped resource	{"controller": "kruize", "controllerGroup": "my.domain", "controllerKind": "Kruize", "Kruize": {"name":"kruize-sample","namespace":"openshift-tuning"}, "namespace": "openshift-tuning", "name": "kruize-sample", "reconcileID": "69bd4eb7-5ce3-4193-9301-69e18ac8e016", "Kind": "ClusterRole", "Name": "kruize-recommendation-updater"}
2025-11-10T05:40:23Z	ERROR	Failed to reconcile cluster-scoped resource	{"controller": "kruize", "controllerGroup": "my.domain", "controllerKind": "Kruize", "Kruize": {"name":"kruize-sample","namespace":"openshift-tuning"}, "namespace": "openshift-tuning", "name": "kruize-sample", "reconcileID": "69bd4eb7-5ce3-4193-9301-69e18ac8e016", "Kind": "ClusterRole", "Name": "kruize-recommendation-updater", "error": "clusterroles.rbac.authorization.k8s.io \"kruize-recommendation-updater\" is forbidden: user \"system:serviceaccount:kruize-operator-system:kruize-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:kruize-operator-system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"endpoints\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"\"], Resources:[\"nodes\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"apps\"], Resources:[\"daemonsets\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"apps\"], Resources:[\"statefulsets\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"autoscaling.k8s.io\"], Resources:[\"verticalpodautoscalers\"], Verbs:[\"list\" \"watch\" \"update\" \"patch\"]}\n{APIGroups:[\"extensions\"], Resources:[\"ingresses\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"metrics.k8s.io\"], Resources:[\"nodes\"], Verbs:[\"list\"]}\n{APIGroups:[\"monitoring.coreos.com\"], Resources:[\"alertmanagers\"], ResourceNames:[\"*\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"monitoring.coreos.com\"], Resources:[\"prometheuses\"], ResourceNames:[\"*\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"monitoring.coreos.com\"], Resources:[\"prometheuses/api\"], Verbs:[\"update\"]}\n{APIGroups:[\"monitoring.coreos.com\"], Resources:[\"servicemonitors\"], ResourceNames:[\"*\"], Verbs:[\"list\" \"watch\"]}\n{APIGroups:[\"networking.k8s.io\"], Resources:[\"ingresses\"], Verbs:[\"list\" \"watch\"]}"}
github.com/kruize/kruize-operator/internal/controller.(*KruizeReconciler).deployKruizeComponents
```

-  `list and watch` permissions for resources -

    >  endpoints, nodes, daemonsets, statefulsets, vpa, ingresses, alertmanagers, prometheuses, servicemonitors, 

- `update and patch` permissions for resource - `verticalpodautoscaler`
- `update` permission for resource - `prometheuses/api`


docker image - `quay.io/shbirada/kruize-operator:pr26` 