### PR TITLE
Update operator version to 0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.2-rc2
+VERSION ?= 0.0.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     createdAt: "2025-06-24T06:44:54Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: kruize-operator.v0.0.2-rc2
+  name: kruize-operator.v0.0.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -38,4 +38,4 @@ spec:
   maturity: alpha
   provider:
     name: ncaughey
-  version: 0.0.2-rc2
+  version: 0.0.2


### PR DESCRIPTION
This PR updates operator version to `0.0.2`

Expected behaviour

- `make deploy` by default should deploy  latest operator image - `quay.io/kruize/kruize-operator:0.0.2`
- `make deploy IMG=<user-specified-image>` should deploy user specified operator image