### PR TITLE
Updated kruize image tag to 0.8.1

### DIFF
--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
           },
           "spec": {
             "autotune_configmaps": "autotune-configmaps",
-            "autotune_image": "quay.io/kruize/autotune_operator:0.8",
+            "autotune_image": "quay.io/kruize/autotune_operator:0.8.1",
             "autotune_ui_image": "quay.io/kruize/kruize-ui:0.0.9",
             "cluster_type": "openshift",
             "namespace": "openshift-tuning",

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
-  autotune_image: "quay.io/kruize/autotune_operator:0.8"
+  size: 3
+  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the sample Kruize configuration references the correct autotune operator image version 0.8.1 instead of 0.8.