### PR TITLE
Add constants for Kruize images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ For examples of running Kruize and the operator, see [kruize-demos](https://gith
 
 The operator supports the following environment variables for customizing default container images:
 
-| Variable | Description | Default Value |
-|----------|-------------|---------------|
-| `DEFAULT_AUTOTUNE_IMAGE` | Override the default Kruize Autotune container image | `quay.io/kruize/autotune_operator:0.8.1` |
-| `DEFAULT_AUTOTUNE_UI_IMAGE` | Override the default Kruize UI container image | `quay.io/kruize/kruize-ui:0.0.9` |
+| Variable | Description |
+|----------|-------------|
+| `DEFAULT_AUTOTUNE_IMAGE` | Override the default Kruize Autotune container image |
+| `DEFAULT_AUTOTUNE_UI_IMAGE` | Override the default Kruize UI container image |
+
 
 **Example Usage:**
 ```sh
@@ -46,7 +47,7 @@ export DEFAULT_AUTOTUNE_IMAGE="my-registry.io/kruize/autotune_operator:custom-ta
 export DEFAULT_AUTOTUNE_UI_IMAGE="my-registry.io/kruize/kruize-ui:custom-tag"
 ```
 
-These environment variables are checked when the operator creates Kruize resources with empty `autotune_image` or `autotune_ui_image` fields in the CR spec. If the CR explicitly specifies image values, those take precedence over both environment variables and built-in defaults.
+These environment variables are checked once at operator startup. When the operator creates Kruize resources with empty `autotune_image` or `autotune_ui_image` fields in the CR spec, it uses these environment variable values (if set) or the built-in defaults. If the CR explicitly specifies image values, those take precedence over environment variables.
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ For examples of running Kruize and the operator, see [kruize-demos](https://gith
 - [operator-sdk](https://github.com/operator-framework/operator-sdk) v1.37.0+ (as specified in Makefile)
 - Docker version 17.03+
 
+### Configuration
+
+**Environment Variables:**
+
+The operator supports the following environment variables for customizing default container images:
+
+| Variable | Description | Default Value |
+|----------|-------------|---------------|
+| `DEFAULT_AUTOTUNE_IMAGE` | Override the default Kruize Autotune container image | `quay.io/kruize/autotune_operator:0.8.1` |
+| `DEFAULT_AUTOTUNE_UI_IMAGE` | Override the default Kruize UI container image | `quay.io/kruize/kruize-ui:0.0.9` |
+
+**Example Usage:**
+```sh
+# Use custom registry/versions
+export DEFAULT_AUTOTUNE_IMAGE="my-registry.io/kruize/autotune_operator:custom-tag"
+export DEFAULT_AUTOTUNE_UI_IMAGE="my-registry.io/kruize/kruize-ui:custom-tag"
+```
+
+These environment variables are checked when the operator creates Kruize resources with empty `autotune_image` or `autotune_ui_image` fields in the CR spec. If the CR explicitly specifies image values, those take precedence over both environment variables and built-in defaults.
+
 ### Deployment
 
 The operator uses Kustomize overlays to manage platform-specific configurations:

--- a/internal/constants/cluster_types.go
+++ b/internal/constants/cluster_types.go
@@ -32,6 +32,15 @@ const (
 	ClusterTypeKind      = "kind"
 )
 
+// Default container image versions
+const (
+	// DefaultAutotuneImage is the default container image for Kruize Autotune
+	DefaultAutotuneImage = "quay.io/kruize/autotune_operator:0.8.1"
+
+	// DefaultAutotuneUIImage is the default container image for Kruize UI
+	DefaultAutotuneUIImage = "quay.io/kruize/kruize-ui:0.0.9"
+)
+
 // NormalizeClusterType converts user input to lowercase for internal use
 // This allows case-insensitive cluster type matching (e.g., "OpenShift", "OPENSHIFT", "openshift" all work)
 func NormalizeClusterType(clusterType string) string {

--- a/internal/constants/cluster_types.go
+++ b/internal/constants/cluster_types.go
@@ -32,15 +32,6 @@ const (
 	ClusterTypeKind      = "kind"
 )
 
-// Default container image versions
-const (
-	// DefaultAutotuneImage is the default container image for Kruize Autotune
-	DefaultAutotuneImage = "quay.io/kruize/autotune_operator:0.8.1"
-
-	// DefaultAutotuneUIImage is the default container image for Kruize UI
-	DefaultAutotuneUIImage = "quay.io/kruize/kruize-ui:0.0.9"
-)
-
 // NormalizeClusterType converts user input to lowercase for internal use
 // This allows case-insensitive cluster type matching (e.g., "OpenShift", "OPENSHIFT", "openshift" all work)
 func NormalizeClusterType(clusterType string) string {

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -18,6 +18,15 @@ package constants
 
 import "os"
 
+// Environment variable names for image overrides
+const (
+	// envAutotuneImage is the environment variable name for overriding the default Autotune image
+	envAutotuneImage = "DEFAULT_AUTOTUNE_IMAGE"
+	
+	// envAutotuneUIImage is the environment variable name for overriding the default Autotune UI image
+	envAutotuneUIImage = "DEFAULT_AUTOTUNE_UI_IMAGE"
+)
+
 // Default container image versions
 const (
 	// defaultAutotuneImageTag is the default tag for Kruize Autotune image
@@ -36,7 +45,7 @@ const (
 // GetDefaultAutotuneImage returns the default Autotune image, checking environment variables first
 func GetDefaultAutotuneImage() string {
 	// Check for environment variable override
-	if envImage := os.Getenv("DEFAULT_AUTOTUNE_IMAGE"); envImage != "" {
+	if envImage := os.Getenv(envAutotuneImage); envImage != "" {
 		return envImage
 	}
 	return defaultAutotuneImageRepo + ":" + defaultAutotuneImageTag
@@ -45,7 +54,7 @@ func GetDefaultAutotuneImage() string {
 // GetDefaultAutotuneUIImage returns the default Autotune UI image, checking environment variables first
 func GetDefaultAutotuneUIImage() string {
 	// Check for environment variable override
-	if envImage := os.Getenv("DEFAULT_AUTOTUNE_UI_IMAGE"); envImage != "" {
+	if envImage := os.Getenv(envAutotuneUIImage); envImage != "" {
 		return envImage
 	}
 	return defaultAutotuneUIImageRepo + ":" + defaultAutotuneUIImageTag

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -20,17 +20,17 @@ import "os"
 
 // Default container image versions
 const (
-	// DefaultAutotuneImageTag is the default tag for Kruize Autotune image
-	DefaultAutotuneImageTag = "0.8.1"
+	// defaultAutotuneImageTag is the default tag for Kruize Autotune image
+	defaultAutotuneImageTag = "0.8.1"
 	
-	// DefaultAutotuneUIImageTag is the default tag for Kruize UI image
-	DefaultAutotuneUIImageTag = "0.0.9"
+	// defaultAutotuneUIImageTag is the default tag for Kruize UI image
+	defaultAutotuneUIImageTag = "0.0.9"
 	
-	// DefaultAutotuneImageRepo is the default repository for Kruize Autotune image
-	DefaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
+	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
+	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
 	
-	// DefaultAutotuneUIImageRepo is the default repository for Kruize UI image
-	DefaultAutotuneUIImageRepo = "quay.io/kruize/kruize-ui"
+	// defaultAutotuneUIImageRepo is the default repository for Kruize UI image
+	defaultAutotuneUIImageRepo = "quay.io/kruize/kruize-ui"
 )
 
 // GetDefaultAutotuneImage returns the default Autotune image, checking environment variables first
@@ -39,7 +39,7 @@ func GetDefaultAutotuneImage() string {
 	if envImage := os.Getenv("DEFAULT_AUTOTUNE_IMAGE"); envImage != "" {
 		return envImage
 	}
-	return DefaultAutotuneImageRepo + ":" + DefaultAutotuneImageTag
+	return defaultAutotuneImageRepo + ":" + defaultAutotuneImageTag
 }
 
 // GetDefaultAutotuneUIImage returns the default Autotune UI image, checking environment variables first
@@ -48,5 +48,5 @@ func GetDefaultAutotuneUIImage() string {
 	if envImage := os.Getenv("DEFAULT_AUTOTUNE_UI_IMAGE"); envImage != "" {
 		return envImage
 	}
-	return DefaultAutotuneUIImageRepo + ":" + DefaultAutotuneUIImageTag
+	return defaultAutotuneUIImageRepo + ":" + defaultAutotuneUIImageTag
 }

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -23,8 +23,8 @@ const (
 	// envAutotuneImage is the environment variable name for overriding the default Autotune image
 	envAutotuneImage = "DEFAULT_AUTOTUNE_IMAGE"
 	
-	// envAutotuneUIImage is the environment variable name for overriding the default Autotune UI image
-	envAutotuneUIImage = "DEFAULT_AUTOTUNE_UI_IMAGE"
+	// envUIImage is the environment variable name for overriding the default Kruize UI image
+	envUIImage = "DEFAULT_AUTOTUNE_UI_IMAGE"
 )
 
 // Default container image versions
@@ -32,14 +32,14 @@ const (
 	// defaultAutotuneImageTag is the default tag for Kruize Autotune image
 	defaultAutotuneImageTag = "0.8.1"
 	
-	// defaultAutotuneUIImageTag is the default tag for Kruize UI image
-	defaultAutotuneUIImageTag = "0.0.9"
+	// defaultUIImageTag is the default tag for Kruize UI image
+	defaultUIImageTag = "0.0.9"
 	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
 	
-	// defaultAutotuneUIImageRepo is the default repository for Kruize UI image
-	defaultAutotuneUIImageRepo = "quay.io/kruize/kruize-ui"
+	// defaultUIImageRepo is the default repository for Kruize UI image
+	defaultUIImageRepo = "quay.io/kruize/kruize-ui"
 )
 
 // Package-level variables that cache the resolved default images.
@@ -47,7 +47,7 @@ const (
 // environment variable lookups on every function call.
 var (
 	defaultAutotuneImage   string
-	defaultAutotuneUIImage string
+	defaultUIImage string
 )
 
 // init resolves the default images by checking environment variables once at package initialization.
@@ -61,10 +61,10 @@ func init() {
 	}
 	
 	// Resolve Autotune UI image
-	if envImage := os.Getenv(envAutotuneUIImage); envImage != "" {
-		defaultAutotuneUIImage = envImage
+	if envImage := os.Getenv(envUIImage); envImage != "" {
+		defaultUIImage = envImage
 	} else {
-		defaultAutotuneUIImage = defaultAutotuneUIImageRepo + ":" + defaultAutotuneUIImageTag
+		defaultUIImage = defaultUIImageRepo + ":" + defaultUIImageTag
 	}
 }
 
@@ -74,8 +74,8 @@ func GetDefaultAutotuneImage() string {
 	return defaultAutotuneImage
 }
 
-// GetDefaultAutotuneUIImage returns the cached default Autotune UI image.
+// GetDefaultUIImage returns the cached default Autotune UI image.
 // The image is resolved once at package initialization from environment variables or defaults.
-func GetDefaultAutotuneUIImage() string {
-	return defaultAutotuneUIImage
+func GetDefaultUIImage() string {
+	return defaultUIImage
 }

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+// Default container image versions
+const (
+	// DefaultAutotuneImage is the default container image for Kruize Autotune
+	DefaultAutotuneImage = "quay.io/kruize/autotune_operator:0.8.1"
+
+	// DefaultAutotuneUIImage is the default container image for Kruize UI
+	DefaultAutotuneUIImage = "quay.io/kruize/kruize-ui:0.0.9"
+)

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -16,11 +16,37 @@ limitations under the License.
 
 package constants
 
+import "os"
+
 // Default container image versions
 const (
-	// DefaultAutotuneImage is the default container image for Kruize Autotune
-	DefaultAutotuneImage = "quay.io/kruize/autotune_operator:0.8.1"
-
-	// DefaultAutotuneUIImage is the default container image for Kruize UI
-	DefaultAutotuneUIImage = "quay.io/kruize/kruize-ui:0.0.9"
+	// DefaultAutotuneImageTag is the default tag for Kruize Autotune image
+	DefaultAutotuneImageTag = "0.8.1"
+	
+	// DefaultAutotuneUIImageTag is the default tag for Kruize UI image
+	DefaultAutotuneUIImageTag = "0.0.9"
+	
+	// DefaultAutotuneImageRepo is the default repository for Kruize Autotune image
+	DefaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
+	
+	// DefaultAutotuneUIImageRepo is the default repository for Kruize UI image
+	DefaultAutotuneUIImageRepo = "quay.io/kruize/kruize-ui"
 )
+
+// GetDefaultAutotuneImage returns the default Autotune image, checking environment variables first
+func GetDefaultAutotuneImage() string {
+	// Check for environment variable override
+	if envImage := os.Getenv("DEFAULT_AUTOTUNE_IMAGE"); envImage != "" {
+		return envImage
+	}
+	return DefaultAutotuneImageRepo + ":" + DefaultAutotuneImageTag
+}
+
+// GetDefaultAutotuneUIImage returns the default Autotune UI image, checking environment variables first
+func GetDefaultAutotuneUIImage() string {
+	// Check for environment variable override
+	if envImage := os.Getenv("DEFAULT_AUTOTUNE_UI_IMAGE"); envImage != "" {
+		return envImage
+	}
+	return DefaultAutotuneUIImageRepo + ":" + DefaultAutotuneUIImageTag
+}

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -42,20 +42,40 @@ const (
 	defaultAutotuneUIImageRepo = "quay.io/kruize/kruize-ui"
 )
 
-// GetDefaultAutotuneImage returns the default Autotune image, checking environment variables first
-func GetDefaultAutotuneImage() string {
-	// Check for environment variable override
+// Package-level variables that cache the resolved default images.
+// These are initialized once at package load time to avoid repeated
+// environment variable lookups on every function call.
+var (
+	defaultAutotuneImage   string
+	defaultAutotuneUIImage string
+)
+
+// init resolves the default images by checking environment variables once at package initialization.
+// This caching approach improves performance and makes behavior more predictable.
+func init() {
+	// Resolve Autotune image
 	if envImage := os.Getenv(envAutotuneImage); envImage != "" {
-		return envImage
+		defaultAutotuneImage = envImage
+	} else {
+		defaultAutotuneImage = defaultAutotuneImageRepo + ":" + defaultAutotuneImageTag
 	}
-	return defaultAutotuneImageRepo + ":" + defaultAutotuneImageTag
+	
+	// Resolve Autotune UI image
+	if envImage := os.Getenv(envAutotuneUIImage); envImage != "" {
+		defaultAutotuneUIImage = envImage
+	} else {
+		defaultAutotuneUIImage = defaultAutotuneUIImageRepo + ":" + defaultAutotuneUIImageTag
+	}
 }
 
-// GetDefaultAutotuneUIImage returns the default Autotune UI image, checking environment variables first
+// GetDefaultAutotuneImage returns the cached default Autotune image.
+// The image is resolved once at package initialization from environment variables or defaults.
+func GetDefaultAutotuneImage() string {
+	return defaultAutotuneImage
+}
+
+// GetDefaultAutotuneUIImage returns the cached default Autotune UI image.
+// The image is resolved once at package initialization from environment variables or defaults.
 func GetDefaultAutotuneUIImage() string {
-	// Check for environment variable override
-	if envImage := os.Getenv(envAutotuneUIImage); envImage != "" {
-		return envImage
-	}
-	return defaultAutotuneUIImageRepo + ":" + defaultAutotuneUIImageTag
+	return defaultAutotuneUIImage
 }

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -87,8 +87,8 @@ var _ = Describe("Kruize Controller", func() {
 					Spec: kruizev1alpha1.KruizeSpec{
 						Cluster_type:      clusterType,
 						Namespace:         namespace,
-						Autotune_image:    "quay.io/kruize/autotune_operator:0.8.1",
-						Autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9",
+						Autotune_image:    constants.DefaultAutotuneImage,
+						Autotune_ui_image: constants.DefaultAutotuneUIImage,
 					},
 				}
 				Expect(k8sClient.Create(ctx, kruize)).To(Succeed())
@@ -125,8 +125,8 @@ var _ = Describe("Kruize Controller", func() {
 					Spec: kruizev1alpha1.KruizeSpec{
 						Cluster_type:      clusterType,
 						Namespace:         "test",
-						Autotune_image:    "quay.io/kruize/autotune_operator:0.8.1",
-						Autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9",
+						Autotune_image:    constants.DefaultAutotuneImage,
+						Autotune_ui_image: constants.DefaultAutotuneUIImage,
 					},
 				}
 				Expect(k8sClient.Create(ctx, kruize)).To(Succeed())
@@ -170,8 +170,8 @@ var _ = Describe("Kruize Controller", func() {
 					Spec: kruizev1alpha1.KruizeSpec{
 						Cluster_type:      clusterType,
 						Namespace:         namespace,
-						Autotune_image:    "quay.io/kruize/autotune_operator:0.8.1",
-						Autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9",
+						Autotune_image:    constants.DefaultAutotuneImage,
+						Autotune_ui_image: constants.DefaultAutotuneUIImage,
 					},
 				}
 				Expect(k8sClient.Create(ctx, kruize)).To(Succeed())
@@ -210,8 +210,8 @@ var _ = Describe("Kruize Controller", func() {
 					Spec: kruizev1alpha1.KruizeSpec{
 						Cluster_type:      clusterType,
 						Namespace:         testNamespace,
-						Autotune_image:    "quay.io/kruize/autotune_operator:0.8.1",
-						Autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9",
+						Autotune_image:    constants.DefaultAutotuneImage,
+						Autotune_ui_image: constants.DefaultAutotuneUIImage,
 					},
 				}
 				Expect(k8sClient.Create(ctx, kruize)).To(Succeed())
@@ -307,8 +307,8 @@ var _ = Describe("Kruize Controller", func() {
 		It("should use default images when not specified", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift)
 
-			Expect(generator.Autotune_image).To(Equal("quay.io/kruize/autotune_operator:0.8.1"))
-			Expect(generator.Autotune_ui_image).To(Equal("quay.io/kruize/kruize-ui:0.0.9"))
+			Expect(generator.Autotune_image).To(Equal(constants.DefaultAutotuneImage))
+			Expect(generator.Autotune_ui_image).To(Equal(constants.DefaultAutotuneUIImage))
 		})
 
 		It("should use custom images when specified", func() {

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -38,10 +38,10 @@ type KruizeResourceGenerator struct {
 func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string, clusterType string) *KruizeResourceGenerator {
 	// If no image is provided from the CR, use a sensible default.
 	if autotuneImage == "" {
-		autotuneImage = "quay.io/kruize/autotune_operator:latest"
+		autotuneImage = constants.DefaultAutotuneImage
 	}
 	if autotuneUIImage == "" {
-		autotuneUIImage = "quay.io/kruize/kruize-ui:0.0.9"
+		autotuneUIImage = constants.DefaultAutotuneUIImage
 	}
 	if clusterType == "" {
 		clusterType = constants.ClusterTypeOpenShift // Default to openshift for backward compatibility

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -37,11 +37,14 @@ type KruizeResourceGenerator struct {
 // NewKruizeResourceGenerator creates a new generator for Kruize resources.
 func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string, clusterType string) *KruizeResourceGenerator {
 	// If no image is provided from the CR, use a sensible default.
+	// The default can be configured via environment variables:
+	// - DEFAULT_AUTOTUNE_IMAGE: Override the default Autotune image
+	// - DEFAULT_AUTOTUNE_UI_IMAGE: Override the default Autotune UI image
 	if autotuneImage == "" {
-		autotuneImage = constants.DefaultAutotuneImage
+		autotuneImage = constants.GetDefaultAutotuneImage()
 	}
 	if autotuneUIImage == "" {
-		autotuneUIImage = constants.DefaultAutotuneUIImage
+		autotuneUIImage = constants.GetDefaultAutotuneUIImage()
 	}
 	if clusterType == "" {
 		clusterType = constants.ClusterTypeOpenShift // Default to openshift for backward compatibility

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -44,7 +44,7 @@ func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotune
 		autotuneImage = constants.GetDefaultAutotuneImage()
 	}
 	if autotuneUIImage == "" {
-		autotuneUIImage = constants.GetDefaultAutotuneUIImage()
+		autotuneUIImage = constants.GetDefaultUIImage()
 	}
 	if clusterType == "" {
 		clusterType = constants.ClusterTypeOpenShift // Default to openshift for backward compatibility


### PR DESCRIPTION
This PR adds default constants for Kruize Autotune and UI images.

## Summary by Sourcery

Introduce centralized, configurable defaults for Kruize Autotune and UI container images and update resource generation to use them.

New Features:
- Add helper functions to provide default Kruize Autotune and UI images with optional environment variable overrides.

Enhancements:
- Refactor Kruize resource generation and controller tests to use shared default-image helpers instead of hard-coded image strings.

Documentation:
- Document environment variables for overriding default Kruize Autotune and UI images in the README, including example usage.

Tests:
- Add and update tests to verify defaulting behavior and custom override handling for Kruize Autotune and UI images.