### PR TITLE
Update Dockerfile to use UBI base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -25,8 +26,9 @@ COPY internal/constants/ internal/constants/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1766033715
-WORKDIR /
-COPY --from=builder /opt/app-root/src/manager .
+WORKDIR /app
+
+COPY --from=builder /workspace/manager .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/app/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -24,7 +24,7 @@ COPY internal/constants/ internal/constants/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1766033715
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
 USER 65532:65532

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1766033715
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
This PR updates Dockerfile to use Red Hat UBI base images.

Quay image: `quay.io/shbirada/ubi-image:ubi10`