### PR TITLE
Refactor RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,7 +33,6 @@ rules:
   resources:
   - namespaces
   verbs:
-  - create
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,7 +102,6 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - create
   - get
   - list
   - watch
@@ -180,7 +179,6 @@ rules:
   resources:
   - jobs
   verbs:
-  - create
   - get
   - list
 - apiGroups:
@@ -188,7 +186,6 @@ rules:
   resources:
   - ingresses
   verbs:
-  - create
   - get
   - list
   - watch
@@ -205,7 +202,6 @@ rules:
   resources:
   - kruizes
   verbs:
-  - create
   - get
   - list
   - watch
@@ -244,22 +240,16 @@ rules:
   resources:
   - alertmanagers
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheuses
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - monitoring.coreos.com
@@ -268,21 +258,7 @@ rules:
   verbs:
   - create
   - get
-  - list
-  - patch
   - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheusrules
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -299,7 +275,6 @@ rules:
   resources:
   - ingresses
   verbs:
-  - create
   - get
   - list
   - watch
@@ -360,7 +335,6 @@ rules:
   resources:
   - securitycontextconstraints
   verbs:
-  - create
   - get
   - use
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -334,7 +334,6 @@ rules:
   resources:
   - securitycontextconstraints
   verbs:
-  - get
   - use
 - apiGroups:
   - storage.k8s.io

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -69,7 +69,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=inference.redhat.com,resources=instaslices,verbs=get;list;watch
@@ -77,8 +77,8 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;create;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;use
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
@@ -93,7 +93,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes,verbs=get;list;
+//+kubebuilder:rbac:groups=metrics.k8s.io,resources=nodes,verbs=get;list
 //+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers/status,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalercheckpoints,verbs=get;list;watch;create;update;patch

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -54,7 +54,7 @@ type KruizeReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=kruize.io,resources=kruizes,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=kruize.io,resources=kruizes,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=kruize.io,resources=kruizes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kruize.io,resources=kruizes/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -69,7 +69,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;create
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=inference.redhat.com,resources=instaslices,verbs=get;list;watch
@@ -77,20 +77,19 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;create;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;create;use
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;create;list;watch
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;use
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create;update
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=get;list;watch;create

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -65,7 +65,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create
@@ -291,14 +291,6 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 
 	if clusterType == constants.ClusterTypeOpenShift {
 		// OpenShift-specific resources
-
-        	// Reconcile Namespace FIRST (no owner reference)
-        	kruizeNamespace := k8sObjectGenerator.KruizeNamespace()
-        	if err := r.reconcileClusterResource(ctx, kruizeNamespace); err != nil {
-            		logger.Error(err, "Failed to reconcile Namespace")
-            		return err
-        	}
-
         	kruizeServiceAccount := k8sObjectGenerator.KruizeServiceAccount()
         	if err := r.reconcileClusterResource(ctx, kruizeServiceAccount); err != nil {
             		logger.Error(err, "Failed to reconcile kruize service account")

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -54,7 +54,7 @@ type KruizeReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=kruize.io,resources=kruizes,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=kruize.io,resources=kruizes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kruize.io,resources=kruizes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kruize.io,resources=kruizes/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -80,7 +80,7 @@ type KruizeReconciler struct {
 //+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;use
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -138,19 +138,6 @@ func (g *KruizeResourceGenerator) generateRoute(name, serviceName, targetPort st
 }
 
 // kruizeServiceAccount generates the ServiceAccount for Kruize.
-func (g *KruizeResourceGenerator) KruizeNamespace() *corev1.Namespace {
-	return &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: g.Namespace,
-		},
-	}
-}
-
-// kruizeServiceAccount generates the ServiceAccount for Kruize.
 func (g *KruizeResourceGenerator) KruizeServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -91,8 +91,8 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 		g.deletePartitionCronJob(),
 	}
 
-    objects = append(objects, g.Routes()...)
-    return objects
+	objects = append(objects, g.Routes()...)
+	return objects
 }
 
 func (g *KruizeResourceGenerator) Routes() []client.Object {
@@ -179,11 +179,10 @@ func (g *KruizeResourceGenerator) recommendationUpdaterClusterRole() *rbacv1.Clu
 			{APIGroups: []string{""}, Resources: []string{"nodes", "namespaces", "services", "endpoints"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"apps"}, Resources: []string{"deployments", "replicasets", "statefulsets", "daemonsets"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"extensions", "networking.k8s.io"}, Resources: []string{"ingresses"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"autoscaling.k8s.io"}, Resources: []string{"verticalpodautoscalers"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch"}},
 			{APIGroups: []string{"metrics.k8s.io"}, Resources: []string{"pods", "nodes"}, Verbs: []string{"get", "list"}},
 			{APIGroups: []string{"monitoring.coreos.com"}, Resources: []string{"prometheuses", "alertmanagers", "servicemonitors"}, Verbs: []string{"get", "list", "watch"}, ResourceNames: []string{"*"}},
 			{APIGroups: []string{"monitoring.coreos.com"}, Resources: []string{"prometheuses/api"}, Verbs: []string{"get", "create", "update"}},
-			{APIGroups: []string{"apiextensions.k8s.io"}, Resources: []string{"customresourcedefinitions"}, Verbs: []string{"get", "list", "watch", "create"}},
+			{APIGroups: []string{"apiextensions.k8s.io"}, Resources: []string{"customresourcedefinitions"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"autoscaling.k8s.io"}, Resources: []string{"verticalpodautoscalers", "verticalpodautoscalers/status", "verticalpodautoscalercheckpoints"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch"}},
 			{APIGroups: []string{"rbac.authorization.k8s.io"}, Resources: []string{"clusterrolebindings"}, Verbs: []string{"get", "list", "watch", "create"}},
 			{NonResourceURLs: []string{"/metrics", "/api/v1/label/*", "/api/v1/query*", "/api/v1/series*", "/api/v1/targets*"}, Verbs: []string{"get"}},


### PR DESCRIPTION
Refactors and reduces Operator RBAC permissions.

Permissions removed:

- `create` permission for `customresourcedefinitions` 
- `jobs` - `create`
- `ingresses` - `create`
- `kruizes` -  `create`
- `alertmanagers` - `create, update, patch`
- `prometheuses` - `create, update, patch`
- `prometheuses/api` - `list, patch, watch `
- `prometheusrules` - removed all permissions
- `namespaces` - `create`
- `securitycontextconstraints` - `create, get`

Fixes issue #45 

Docker image: `quay.io/shbirada/reduce_rbac_permissions:v4`
## Summary by Sourcery

Tighten the operator’s RBAC permissions to follow least-privilege principles and clean up related configuration.

Enhancements:
- Remove unnecessary create, update, and patch permissions from various Kubernetes and monitoring resources in the ClusterRole and kubebuilder RBAC annotations, limiting the operator mostly to read-only access where writes are not required.
- Align the generated recommendation updater ClusterRole with the reduced permission set, including dropping create rights on custom resource definitions and nonessential resources.
- Fix minor formatting in the Kruize resource generator to keep code style consistent.

## Summary by Sourcery

Tighten the operator’s RBAC to follow least-privilege principles while keeping functionality intact.

Enhancements:
- Reduce RBAC permissions in the ClusterRole and kubebuilder annotations, shifting several resources to read-only access and dropping unnecessary create/update/patch verbs.
- Align the generated recommendation updater ClusterRole and related RBAC rules with the updated permission set, including removing create rights on custom resource definitions and other nonessential resources.
- Clean up minor formatting in the Kruize resource generator code for consistency.