### PR TITLE
Rename Operator resources 

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: default
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: kruize-operator-
+namePrefix: kruize-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: operator
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: operator
   namespace: system
 spec:
   template:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/kruize/kruize-operator
-  newTag: 0.0.3
+  newName: quay.io/shbirada/update_operator_name
+  newTag: v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: operator
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: operator
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -83,5 +83,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: operator
       terminationGracePeriodSeconds: 10

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -3,10 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: operator
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-monitor
+  name: operator-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -18,4 +18,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: operator

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: metrics-reader
+  name: operator-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: proxy-role
+  name: operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: proxy-rolebinding
+  name: operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: proxy-role
+  name: operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: operator
   namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: operator
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: operator-metrics-service
   namespace: system
 spec:
   ports:
@@ -14,4 +14,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: operator

--- a/config/rbac/kruize_editor_role.yaml
+++ b/config/rbac/kruize_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: kruize-editor-role
+  name: operator-kruize-editor-role
 rules:
 - apiGroups:
   - kruize.io

--- a/config/rbac/kruize_viewer_role.yaml
+++ b/config/rbac/kruize_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: kruize-viewer-role
+  name: operator-kruize-viewer-role
 rules:
 - apiGroups:
   - kruize.io

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: leader-election-role
+  name: operator-leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: leader-election-rolebinding
+  name: operator-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: operator
   namespace: system

--- a/config/rbac/permission_granter_role.yaml
+++ b/config/rbac/permission_granter_role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: permission-granter
+  name: operator-permission-granter
 rules:
   - apiGroups: ["apps"]
     resources: ["replicasets", "daemonsets"]

--- a/config/rbac/permission_granter_role_binding.yaml
+++ b/config/rbac/permission_granter_role_binding.yaml
@@ -4,14 +4,14 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: permission-granter-binding
+  name: operator-permission-granter-binding
 subjects:
   - kind: ServiceAccount
-    name: controller-manager
+    name: operator
     # namespace: system is a placeholder that kustomize automatically transforms
     # to the target namespace (monitoring, openshift-tuning, etc.) during build
     namespace: system
 roleRef:
   kind: ClusterRole
-  name: permission-granter
+  name: operator-permission-granter
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: operator-manager-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -4,14 +4,14 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: operator
   # namespace: system is a placeholder that kustomize automatically transforms
   # to the target namespace (monitoring, openshift-tuning, etc.) during build
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -4,5 +4,5 @@ metadata:
   labels:
     app.kubernetes.io/name: kruize-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager
+  name: operator
   namespace: system


### PR DESCRIPTION
This PR renames deployment `kruize-operator-controller-manager` to `kruize-operator` and corresponding other resources

## Summary by Sourcery

Rename operator Kubernetes resources from controller-manager to operator and align related labels, RBAC, service, and monitoring configuration.

Enhancements:
- Standardize the operator deployment, service account, RBAC roles/bindings, and monitoring resources on the operator naming convention instead of controller-manager.
- Adjust the default name prefix for generated resources to use a shorter kruize- prefix.
- Point the manager image configuration to the temporary update_operator_name image and tag for the renamed operator.