### PR TITLE
Bundle Kruize Operator 0.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= quay.io/kruize/kruize-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+BUNDLE_GEN_FLAGS ?= -q --overwrite=false --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests

--- a/bundle/manifests/kruize-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kruize-operator-metrics-service_v1_service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: kruize-operator
-    control-plane: controller-manager
-  name: kruize-operator-controller-manager-metrics-service
+    control-plane: kruize-operator
+  name: kruize-operator-metrics-service
 spec:
   ports:
   - name: https
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: kruize-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -15,7 +15,6 @@ metadata:
             "name": "kruize-sample"
           },
           "spec": {
-            "autotune_configmaps": "autotune-configmaps",
             "autotune_image": "quay.io/kruize/autotune_operator:0.8.1",
             "autotune_ui_image": "quay.io/kruize/kruize-ui:0.0.9",
             "cluster_type": "openshift",
@@ -26,7 +25,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
     containerImage: quay.io/kruize/kruize-operator:0.0.4
-    createdAt: "2026-01-16T09:19:14Z"
+    createdAt: "2026-02-04T08:25:45Z"
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -517,7 +516,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: kruize-operator
+        serviceAccountName: kruize-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/managed-by: kustomize
@@ -595,7 +594,7 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: kruize-operator
+              serviceAccountName: kruize-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -630,7 +629,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: kruize-operator
+        serviceAccountName: kruize-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -19,10 +19,7 @@ metadata:
             "autotune_image": "quay.io/kruize/autotune_operator:0.8.1",
             "autotune_ui_image": "quay.io/kruize/kruize-ui:0.0.9",
             "cluster_type": "openshift",
-            "namespace": "openshift-tuning",
-            "non_interactive": 1,
-            "size": 3,
-            "use_yaml_build": 0
+            "namespace": "openshift-tuning"
           }
         }
       ]
@@ -41,59 +38,36 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Kruize is the Schema for the kruizes API
+    - description: Kruize contains configuration options for controlling the deployment
+        of the Kruize application and its related components. A Kruize instance must
+        be created to instruct the operator to deploy the Kruize application.
       displayName: Kruize
       kind: Kruize
       name: kruizes.kruize.io
       resources:
-      - kind: Deployment
-        name: ''
-        version: v1
-      - kind: Service
-        name: ''
-        version: v1
-      - kind: ServiceAccount
-        name: ''
-        version: v1
       - kind: ConfigMap
-        name: ''
+        name: ""
+        version: v1
+      - kind: Deployment
+        name: ""
         version: v1
       - kind: PersistentVolume
-        name: ''
+        name: ""
         version: v1
       - kind: PersistentVolumeClaim
-        name: ''
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceAccount
+        name: ""
         version: v1
       - kind: StorageClass
-        name: ''
+        name: ""
         version: v1
       specDescriptors:
-      - description: Namespace where Kruize components will be deployed
-        displayName: Namespace
-        path: namespace
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Non-interactive mode flag (1 for enabled, 0 for disabled)
-        displayName: Non Interactive
-        path: non_interactive
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Size of the Kruize deployment
-        displayName: Size
-        path: size
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Use YAML build flag (1 for enabled, 0 for disabled)
-        displayName: Use YAML Build
-        path: use_yaml_build
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: ConfigMaps for Autotune configuration
-        displayName: Autotune ConfigMaps
-        path: autotune_configmaps
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Container image for Autotune operator
+      - description: Container image for Kruize Autotune
         displayName: Autotune Image
         path: autotune_image
         x-descriptors:
@@ -110,6 +84,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:openshift
         - urn:alm:descriptor:com.tectonic.ui:select:minikube
         - urn:alm:descriptor:com.tectonic.ui:select:kind
+      - description: Target namespace for Kruize deployment
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
   description: |
     Kruize is resource optimization tool for Kubernetes that helps you achieve significant cost
@@ -194,7 +173,6 @@ spec:
           resources:
           - namespaces
           verbs:
-          - create
           - get
           - list
           - watch
@@ -263,7 +241,6 @@ spec:
           resources:
           - customresourcedefinitions
           verbs:
-          - create
           - get
           - list
           - watch
@@ -341,7 +318,6 @@ spec:
           resources:
           - jobs
           verbs:
-          - create
           - get
           - list
         - apiGroups:
@@ -349,7 +325,6 @@ spec:
           resources:
           - ingresses
           verbs:
-          - create
           - get
           - list
           - watch
@@ -366,7 +341,6 @@ spec:
           resources:
           - kruizes
           verbs:
-          - create
           - get
           - list
           - watch
@@ -405,22 +379,16 @@ spec:
           resources:
           - alertmanagers
           verbs:
-          - create
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheuses
           verbs:
-          - create
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - monitoring.coreos.com
@@ -429,21 +397,7 @@ spec:
           verbs:
           - create
           - get
-          - list
-          - patch
           - update
-          - watch
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheusrules
-          verbs:
-          - create
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -460,7 +414,6 @@ spec:
           resources:
           - ingresses
           verbs:
-          - create
           - get
           - list
           - watch
@@ -521,8 +474,6 @@ spec:
           resources:
           - securitycontextconstraints
           verbs:
-          - create
-          - get
           - use
         - apiGroups:
           - storage.k8s.io
@@ -566,25 +517,25 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: kruize-operator-controller-manager
+        serviceAccountName: kruize-operator
       deployments:
       - label:
           app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: kruize-operator
-          control-plane: controller-manager
-        name: kruize-operator-controller-manager
+          control-plane: kruize-operator
+        name: kruize-operator
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: kruize-operator
           strategy: {}
           template:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                control-plane: controller-manager
+                control-plane: kruize-operator
             spec:
               containers:
               - args:
@@ -644,7 +595,7 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: kruize-operator-controller-manager
+              serviceAccountName: kruize-operator
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -679,7 +630,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: kruize-operator-controller-manager
+        serviceAccountName: kruize-operator
     strategy: deployment
   installModes:
   - supported: false

--- a/bundle/manifests/kruize.io_kruizes.yaml
+++ b/bundle/manifests/kruize.io_kruizes.yaml
@@ -17,7 +17,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Kruize is the Schema for the kruizes API
+        description: |-
+          Kruize contains configuration options for controlling the deployment of the Kruize
+          application and its related components. A Kruize instance must be created to instruct
+          the operator to deploy the Kruize application.
         properties:
           apiVersion:
             description: |-
@@ -39,36 +42,23 @@ spec:
           spec:
             description: KruizeSpec defines the desired state of Kruize
             properties:
-              autotune_configmaps:
-                type: string
               autotune_image:
+                description: Container image for Kruize Autotune
                 type: string
               autotune_ui_image:
+                description: Container image for Kruize UI
                 type: string
               cluster_type:
+                description: Type of Kubernetes cluster (openshift, minikube, or kind)
                 type: string
               namespace:
+                description: Target namespace for Kruize deployment
                 type: string
-              non_interactive:
-                format: int32
-                type: integer
-              size:
-                description: Foo is an example field of Kruize. Edit kruize_types.go
-                  to remove/update
-                format: int32
-                type: integer
-              use_yaml_build:
-                format: int32
-                type: integer
             required:
-            - autotune_configmaps
             - autotune_image
             - autotune_ui_image
             - cluster_type
             - namespace
-            - non_interactive
-            - size
-            - use_yaml_build
             type: object
           status:
             description: KruizeStatus defines the observed state of Kruize

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kruize/kruize-operator
-  newTag: 0.0.3
+  newTag: 0.0.4

--- a/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
@@ -17,59 +17,36 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Kruize is the Schema for the kruizes API
+    - description: Kruize contains configuration options for controlling the deployment
+        of the Kruize application and its related components. A Kruize instance must
+        be created to instruct the operator to deploy the Kruize application.
       displayName: Kruize
       kind: Kruize
       name: kruizes.kruize.io
       resources:
-      - kind: Deployment
-        name: ''
-        version: v1
-      - kind: Service
-        name: ''
-        version: v1
-      - kind: ServiceAccount
-        name: ''
-        version: v1
       - kind: ConfigMap
-        name: ''
+        name: ""
+        version: v1
+      - kind: Deployment
+        name: ""
         version: v1
       - kind: PersistentVolume
-        name: ''
+        name: ""
         version: v1
       - kind: PersistentVolumeClaim
-        name: ''
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceAccount
+        name: ""
         version: v1
       - kind: StorageClass
-        name: ''
+        name: ""
         version: v1
       specDescriptors:
-      - description: Namespace where Kruize components will be deployed
-        displayName: Namespace
-        path: namespace
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Non-interactive mode flag (1 for enabled, 0 for disabled)
-        displayName: Non Interactive
-        path: non_interactive
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Size of the Kruize deployment
-        displayName: Size
-        path: size
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Use YAML build flag (1 for enabled, 0 for disabled)
-        displayName: Use YAML Build
-        path: use_yaml_build
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: ConfigMaps for Autotune configuration
-        displayName: Autotune ConfigMaps
-        path: autotune_configmaps
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Container image for Autotune operator
+      - description: Container image for Kruize Autotune
         displayName: Autotune Image
         path: autotune_image
         x-descriptors:
@@ -86,6 +63,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:openshift
         - urn:alm:descriptor:com.tectonic.ui:select:minikube
         - urn:alm:descriptor:com.tectonic.ui:select:kind
+      - description: Target namespace for Kruize deployment
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
   description: |
     Kruize is resource optimization tool for Kubernetes that helps you achieve significant cost

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,23 +6,6 @@ resources:
 - ../samples
 - ../scorecard
 
-# Override namePrefix for Deployment and ServiceAccount to keep them as just "kruize-operator"
-patches:
-- target:
-    kind: Deployment
-    name: kruize-operator-kruize-operator
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: kruize-operator
-- target:
-    kind: ServiceAccount
-    name: kruize-operator-kruize-operator
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: kruize-operator
-
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,6 +6,23 @@ resources:
 - ../samples
 - ../scorecard
 
+# Override namePrefix for Deployment and ServiceAccount to keep them as just "kruize-operator"
+patches:
+- target:
+    kind: Deployment
+    name: kruize-operator-kruize-operator
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: kruize-operator
+- target:
+    kind: ServiceAccount
+    name: kruize-operator-kruize-operator
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: kruize-operator
+
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
Bundle file updates for Kruize Operator 0.0.4

## Summary by Sourcery

Update Kruize Operator bundle and configuration for the 0.0.4 release.

Enhancements:
- Simplify the Kruize custom resource schema and descriptors by removing unused fields and clarifying descriptions for deployment-related options.
- Adjust RBAC permissions to drop unnecessary create/patch/update verbs on several resources for a more restrictive security posture.
- Rename and relabel the operator deployment and metrics service from the generic controller-manager naming to a kruize-operator-specific naming convention.
- Update scorecard configuration to use the current kustomize patches field and refresh bundle generation flags to avoid overwriting existing metadata.

Build:
- Bump the operator image tag to 0.0.4 in manager configuration and align bundle metadata timestamps with the new release.