### PR TITLE
Bump Kruize Operator to 0.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.3)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.3)
-VERSION ?= 0.0.3
+# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.4)
+# - use environment variables to overwrite this value (e.g export VERSION=0.0.4)
+VERSION ?= 0.0.4
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -28,14 +28,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.3
+    containerImage: quay.io/kruize/kruize-operator:0.0.4
     createdAt: "2026-01-16T09:19:14Z"
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/kruize/kruize-operator
     support: Kruize Community
-  name: kruize-operator.v0.0.3
+  name: kruize-operator.v0.0.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -616,7 +616,7 @@ spec:
                 - --leader-elect
                 command:
                 - /app/manager
-                image: quay.io/kruize/kruize-operator:0.0.3
+                image: quay.io/kruize/kruize-operator:0.0.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -713,4 +713,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Kruize
-  version: 0.0.3
+  version: 0.0.4

--- a/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.3
+    containerImage: quay.io/kruize/kruize-operator:0.0.4
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
Bump Kruize Operator version references from `0.0.3` to `0.0.4` in `Makefile` and `clusterserviceversion.yaml`

## Summary by Sourcery

Bump Kruize Operator bundle and configuration to version 0.0.4.

Build:
- Update Makefile default VERSION and related examples from 0.0.3 to 0.0.4.

Deployment:
- Update all Kruize Operator container image and CSV version references from 0.0.3 to 0.0.4 in manifest files.