### PR TITLE
Remove prefix 'v' for bundle image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ IMAGE_TAG_BASE ?= quay.io/kruize/kruize-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite=false --version $(VERSION) $(BUNDLE_METADATA_OPTS)


### PR DESCRIPTION
Updates the Makefile removing prefix  `v` for the bundle image version

## Summary by Sourcery

Build:
- Update Makefile bundle image tag to drop the hard-coded 'v' prefix from VERSION when constructing BUNDLE_IMG.