### PR TITLE
Add workflow to sync kruize versions

### DIFF
--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -65,58 +65,48 @@ jobs:
           echo "ui_version=$UI_VERSION" >> $GITHUB_OUTPUT
           echo "Fetched Kruize UI version: $UI_VERSION"
 
-      - name: Check Quay.io for Autotune image tag availability
-        id: check-autotune-image
+      - name: Check Quay.io image availability
+        id: check-images
         run: |
+          # Function to check if an image tag exists on Quay.io
+          check_quay_image() {
+            local REPOSITORY=$1
+            local TAG=$2
+            local IMAGE_NAME=$3
+            
+            IMAGE_URL="https://quay.io/api/v1/repository/${REPOSITORY}/tag/?specificTag=${TAG}"
+            
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$IMAGE_URL")
+            
+            if [ "$HTTP_CODE" -eq 200 ]; then
+              TAG_EXISTS=$(curl -s "$IMAGE_URL" | jq -r '.tags | length')
+              if [ "$TAG_EXISTS" -gt 0 ]; then
+                echo "✓ ${IMAGE_NAME} image tag ${TAG} is available on quay.io"
+                return 0
+              else
+                echo "✗ ${IMAGE_NAME} image tag ${TAG} not found on quay.io (HTTP 200, tag missing)"
+                return 1
+              fi
+            else
+              echo "✗ Failed to check ${IMAGE_NAME} image availability (HTTP ${HTTP_CODE})"
+              return 1
+            fi
+          }
+          
+          # Check Autotune image
           KRUIZE_VERSION="${{ steps.fetch-autotune-version.outputs.kruize_version }}"
-          
-          # Check if the image tag exists on quay.io
-          IMAGE_URL="https://quay.io/api/v1/repository/kruize/autotune_operator/tag/?specificTag=${KRUIZE_VERSION}"
-          
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$IMAGE_URL")
-          
-          if [ "$HTTP_CODE" -eq 200 ]; then
-            # Check if the tag actually exists in the response
-            TAG_EXISTS=$(curl -s "$IMAGE_URL" | jq -r '.tags | length')
-            if [ "$TAG_EXISTS" -gt 0 ]; then
-              echo "image_available=true" >> $GITHUB_OUTPUT
-              echo "Autotune image tag $KRUIZE_VERSION is available on quay.io"
-            else
-              echo "image_available=false" >> $GITHUB_OUTPUT
-              echo "Autotune image tag $KRUIZE_VERSION not found on quay.io (HTTP 200, tag missing)"
-            fi
-          elif [ "$HTTP_CODE" -eq 404 ]; then
-            echo "image_available=false" >> $GITHUB_OUTPUT
-            echo "Autotune image tag $KRUIZE_VERSION not found on quay.io (HTTP 404)"
+          if check_quay_image "kruize/autotune_operator" "$KRUIZE_VERSION" "Autotune"; then
+            echo "autotune_available=true" >> $GITHUB_OUTPUT
           else
-            echo "image_available=false" >> $GITHUB_OUTPUT
-            echo "Error checking Autotune image availability on quay.io (HTTP $HTTP_CODE)"
-            exit 1
+            echo "autotune_available=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Check Quay.io for UI image tag availability
-        id: check-ui-image
-        run: |
+          
+          # Check UI image
           UI_VERSION="${{ steps.fetch-ui-version.outputs.ui_version }}"
-          
-          # Check if the image tag exists on quay.io
-          IMAGE_URL="https://quay.io/api/v1/repository/kruize/kruize-ui/tag/?specificTag=${UI_VERSION}"
-          
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$IMAGE_URL")
-          
-          if [ "$HTTP_CODE" -eq 200 ]; then
-            # Check if the tag actually exists in the response
-            TAG_EXISTS=$(curl -s "$IMAGE_URL" | jq -r '.tags | length')
-            if [ "$TAG_EXISTS" -gt 0 ]; then
-              echo "image_available=true" >> $GITHUB_OUTPUT
-              echo "UI image tag $UI_VERSION is available on quay.io"
-            else
-              echo "image_available=false" >> $GITHUB_OUTPUT
-              echo "UI image tag $UI_VERSION not found on quay.io"
-            fi
+          if check_quay_image "kruize/kruize-ui" "$UI_VERSION" "UI"; then
+            echo "ui_available=true" >> $GITHUB_OUTPUT
           else
-            echo "image_available=false" >> $GITHUB_OUTPUT
-            echo "Failed to check UI image availability (HTTP $HTTP_CODE)"
+            echo "ui_available=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Get current versions from constants
@@ -137,8 +127,8 @@ jobs:
           UI_VERSION="${{ steps.fetch-ui-version.outputs.ui_version }}"
           CURRENT_AUTOTUNE_VERSION="${{ steps.current-versions.outputs.current_autotune_version }}"
           CURRENT_UI_VERSION="${{ steps.current-versions.outputs.current_ui_version }}"
-          AUTOTUNE_IMAGE_AVAILABLE="${{ steps.check-autotune-image.outputs.image_available }}"
-          UI_IMAGE_AVAILABLE="${{ steps.check-ui-image.outputs.image_available }}"
+          AUTOTUNE_IMAGE_AVAILABLE="${{ steps.check-images.outputs.autotune_available }}"
+          UI_IMAGE_AVAILABLE="${{ steps.check-images.outputs.ui_available }}"
           
           NEEDS_AUTOTUNE_UPDATE=false
           NEEDS_UI_UPDATE=false
@@ -225,13 +215,13 @@ jobs:
           echo "### Autotune" >> $GITHUB_STEP_SUMMARY
           echo "- **Version (pom.xml):** ${{ steps.fetch-autotune-version.outputs.kruize_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Current Version (constants):** ${{ steps.current-versions.outputs.current_autotune_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image Available:** ${{ steps.check-autotune-image.outputs.image_available }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image Available:** ${{ steps.check-images.outputs.autotune_available }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Update Needed:** ${{ steps.update-check.outputs.needs_autotune_update }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### UI" >> $GITHUB_STEP_SUMMARY
           echo "- **Version (package.json):** ${{ steps.fetch-ui-version.outputs.ui_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Current Version (constants):** ${{ steps.current-versions.outputs.current_ui_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image Available:** ${{ steps.check-ui-image.outputs.image_available }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image Available:** ${{ steps.check-images.outputs.ui_available }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Update Needed:** ${{ steps.update-check.outputs.needs_ui_update }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Overall" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   check-and-update:
@@ -29,10 +28,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Install XML parsing tools
+      - name: Install required tools
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends libxml2-utils
+          sudo apt-get install -y --no-install-recommends libxml2-utils jq
 
       - name: Fetch Kruize Autotune version from master branch
         id: fetch-autotune-version

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -2,8 +2,8 @@ name: Sync Kruize Versions
 
 on:
   schedule:
-    # Run daily at 00:00 UTC
-    - cron: '0 0 * * *'
+    # Run weekly on Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -28,14 +28,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
       - name: Install required tools
         run: |
           sudo apt-get update -y
@@ -45,9 +37,10 @@ jobs:
         id: fetch-autotune-version
         run: |
           # Fetch the pom.xml from kruize/autotune master branch and extract /project/version
+          # Using local-name() to handle XML namespaces
           KRUIZE_VERSION=$(
             curl -s https://raw.githubusercontent.com/kruize/autotune/master/pom.xml \
-            | xmllint --xpath 'string(/project/version)' - 2>/dev/null
+            | xmllint --xpath '//*[local-name()="project"]/*[local-name()="version"]/text()' - 2>/dev/null
           )
           
           if [ -z "$KRUIZE_VERSION" ]; then

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -28,6 +28,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Install required tools
         run: |
           sudo apt-get update -y
@@ -186,10 +194,11 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "chore: update Kruize versions (Autotune: ${{ steps.fetch-autotune-version.outputs.kruize_version }}, UI: ${{ steps.fetch-ui-version.outputs.ui_version }})"
-          title: "chore: update Kruize image versions"
-          committer: GitHub Actions <actions@github.com>
-          author: GitHub Actions <actions@github.com>
+          commit-message: "build(deps): update Kruize versions to Autotune ${{ steps.fetch-autotune-version.outputs.kruize_version }} and UI ${{ steps.fetch-ui-version.outputs.ui_version }}"
+          title: "build(deps): update Kruize image versions"
+          committer: kruize-version-sync <${{ secrets.APP_ID }}+kruize-version-sync@users.noreply.github.com>
+          author: kruize-version-sync <${{ secrets.APP_ID }}+kruize-version-sync@users.noreply.github.com>
+          sign-commits: true
           body: |
             ## Automated Version Update
             

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -1,0 +1,231 @@
+name: Sync Kruize Versions
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-and-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token from GitHub App
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout kruize-operator repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Fetch Kruize Autotune version from master branch
+        id: fetch-autotune-version
+        run: |
+          # Fetch the pom.xml from kruize/autotune master branch
+          KRUIZE_VERSION=$(curl -s https://raw.githubusercontent.com/kruize/autotune/master/pom.xml | grep -oP '<version>\K[^<]+' | head -1)
+          
+          if [ -z "$KRUIZE_VERSION" ]; then
+            echo "Failed to fetch Kruize Autotune version from pom.xml"
+            exit 1
+          fi
+          
+          echo "kruize_version=$KRUIZE_VERSION" >> $GITHUB_OUTPUT
+          echo "Fetched Kruize Autotune version: $KRUIZE_VERSION"
+
+      - name: Fetch Kruize UI version from master branch
+        id: fetch-ui-version
+        run: |
+          # Fetch the package.json from kruize/kruize-ui master branch
+          UI_VERSION=$(curl -s https://raw.githubusercontent.com/kruize/kruize-ui/main/package.json | jq -r '.version')
+          
+          if [ -z "$UI_VERSION" ] || [ "$UI_VERSION" = "null" ]; then
+            echo "Failed to fetch Kruize UI version from package.json"
+            exit 1
+          fi
+          
+          echo "ui_version=$UI_VERSION" >> $GITHUB_OUTPUT
+          echo "Fetched Kruize UI version: $UI_VERSION"
+
+      - name: Check Quay.io for Autotune image tag availability
+        id: check-autotune-image
+        run: |
+          KRUIZE_VERSION="${{ steps.fetch-autotune-version.outputs.kruize_version }}"
+          
+          # Check if the image tag exists on quay.io
+          IMAGE_URL="https://quay.io/api/v1/repository/kruize/autotune_operator/tag/?specificTag=${KRUIZE_VERSION}"
+          
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$IMAGE_URL")
+          
+          if [ "$HTTP_CODE" -eq 200 ]; then
+            # Check if the tag actually exists in the response
+            TAG_EXISTS=$(curl -s "$IMAGE_URL" | jq -r '.tags | length')
+            if [ "$TAG_EXISTS" -gt 0 ]; then
+              echo "image_available=true" >> $GITHUB_OUTPUT
+              echo "Autotune image tag $KRUIZE_VERSION is available on quay.io"
+            else
+              echo "image_available=false" >> $GITHUB_OUTPUT
+              echo "Autotune image tag $KRUIZE_VERSION not found on quay.io"
+            fi
+          else
+            echo "image_available=false" >> $GITHUB_OUTPUT
+            echo "Failed to check Autotune image availability (HTTP $HTTP_CODE)"
+          fi
+
+      - name: Check Quay.io for UI image tag availability
+        id: check-ui-image
+        run: |
+          UI_VERSION="${{ steps.fetch-ui-version.outputs.ui_version }}"
+          
+          # Check if the image tag exists on quay.io
+          IMAGE_URL="https://quay.io/api/v1/repository/kruize/kruize-ui/tag/?specificTag=${UI_VERSION}"
+          
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$IMAGE_URL")
+          
+          if [ "$HTTP_CODE" -eq 200 ]; then
+            # Check if the tag actually exists in the response
+            TAG_EXISTS=$(curl -s "$IMAGE_URL" | jq -r '.tags | length')
+            if [ "$TAG_EXISTS" -gt 0 ]; then
+              echo "image_available=true" >> $GITHUB_OUTPUT
+              echo "UI image tag $UI_VERSION is available on quay.io"
+            else
+              echo "image_available=false" >> $GITHUB_OUTPUT
+              echo "UI image tag $UI_VERSION not found on quay.io"
+            fi
+          else
+            echo "image_available=false" >> $GITHUB_OUTPUT
+            echo "Failed to check UI image availability (HTTP $HTTP_CODE)"
+          fi
+
+      - name: Get current versions from constants
+        id: current-versions
+        run: |
+          CURRENT_AUTOTUNE_VERSION=$(grep -oP 'defaultAutotuneImageTag = "\K[^"]+' internal/constants/kruize_images.go)
+          CURRENT_UI_VERSION=$(grep -oP 'defaultUIImageTag = "\K[^"]+' internal/constants/kruize_images.go)
+          
+          echo "current_autotune_version=$CURRENT_AUTOTUNE_VERSION" >> $GITHUB_OUTPUT
+          echo "current_ui_version=$CURRENT_UI_VERSION" >> $GITHUB_OUTPUT
+          echo "Current Autotune version in constants: $CURRENT_AUTOTUNE_VERSION"
+          echo "Current UI version in constants: $CURRENT_UI_VERSION"
+
+      - name: Compare versions and determine updates needed
+        id: update-check
+        run: |
+          KRUIZE_VERSION="${{ steps.fetch-autotune-version.outputs.kruize_version }}"
+          UI_VERSION="${{ steps.fetch-ui-version.outputs.ui_version }}"
+          CURRENT_AUTOTUNE_VERSION="${{ steps.current-versions.outputs.current_autotune_version }}"
+          CURRENT_UI_VERSION="${{ steps.current-versions.outputs.current_ui_version }}"
+          AUTOTUNE_IMAGE_AVAILABLE="${{ steps.check-autotune-image.outputs.image_available }}"
+          UI_IMAGE_AVAILABLE="${{ steps.check-ui-image.outputs.image_available }}"
+          
+          NEEDS_AUTOTUNE_UPDATE=false
+          NEEDS_UI_UPDATE=false
+          
+          # Check Autotune version
+          if [ "$AUTOTUNE_IMAGE_AVAILABLE" = "true" ] && [ "$KRUIZE_VERSION" != "$CURRENT_AUTOTUNE_VERSION" ]; then
+            NEEDS_AUTOTUNE_UPDATE=true
+            echo "Autotune version mismatch detected: $CURRENT_AUTOTUNE_VERSION -> $KRUIZE_VERSION"
+          else
+            echo "Autotune version check: No update needed or image not available"
+          fi
+          
+          # Check UI version
+          if [ "$UI_IMAGE_AVAILABLE" = "true" ] && [ "$UI_VERSION" != "$CURRENT_UI_VERSION" ]; then
+            NEEDS_UI_UPDATE=true
+            echo "UI version mismatch detected: $CURRENT_UI_VERSION -> $UI_VERSION"
+          else
+            echo "UI version check: No update needed or image not available"
+          fi
+          
+          # Determine if any update is needed
+          if [ "$NEEDS_AUTOTUNE_UPDATE" = "true" ] || [ "$NEEDS_UI_UPDATE" = "true" ]; then
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+            echo "needs_autotune_update=$NEEDS_AUTOTUNE_UPDATE" >> $GITHUB_OUTPUT
+            echo "needs_ui_update=$NEEDS_UI_UPDATE" >> $GITHUB_OUTPUT
+          else
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "needs_autotune_update=false" >> $GITHUB_OUTPUT
+            echo "needs_ui_update=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update kruize_images.go and sample YAML
+        if: steps.update-check.outputs.needs_update == 'true'
+        run: |
+          KRUIZE_VERSION="${{ steps.fetch-autotune-version.outputs.kruize_version }}"
+          UI_VERSION="${{ steps.fetch-ui-version.outputs.ui_version }}"
+          NEEDS_AUTOTUNE_UPDATE="${{ steps.update-check.outputs.needs_autotune_update }}"
+          NEEDS_UI_UPDATE="${{ steps.update-check.outputs.needs_ui_update }}"
+          
+          # Update Autotune version if needed
+          if [ "$NEEDS_AUTOTUNE_UPDATE" = "true" ]; then
+            sed -i "s/defaultAutotuneImageTag = \"[^\"]*\"/defaultAutotuneImageTag = \"$KRUIZE_VERSION\"/" internal/constants/kruize_images.go
+            sed -i "s|autotune_image: \"quay.io/kruize/autotune_operator:[^\"]*\"|autotune_image: \"quay.io/kruize/autotune_operator:$KRUIZE_VERSION\"|" config/samples/v1alpha1_kruize.yaml
+            echo "Updated Autotune version to $KRUIZE_VERSION"
+          fi
+          
+          # Update UI version if needed
+          if [ "$NEEDS_UI_UPDATE" = "true" ]; then
+            sed -i "s/defaultUIImageTag = \"[^\"]*\"/defaultUIImageTag = \"$UI_VERSION\"/" internal/constants/kruize_images.go
+            sed -i "s|autotune_ui_image: \"quay.io/kruize/kruize-ui:[^\"]*\"|autotune_ui_image: \"quay.io/kruize/kruize-ui:$UI_VERSION\"|" config/samples/v1alpha1_kruize.yaml
+            echo "Updated UI version to $UI_VERSION"
+          fi
+
+      - name: Create Pull Request
+        if: steps.update-check.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "chore: update Kruize versions (Autotune: ${{ steps.fetch-autotune-version.outputs.kruize_version }}, UI: ${{ steps.fetch-ui-version.outputs.ui_version }})"
+          title: "chore: update Kruize image versions"
+          committer: GitHub Actions <actions@github.com>
+          author: GitHub Actions <actions@github.com>
+          body: |
+            ## Automated Version Update
+            
+            Updates Kruize image versions from upstream repositories.
+            
+            **Autotune**: ${{ steps.current-versions.outputs.current_autotune_version }} → ${{ steps.fetch-autotune-version.outputs.kruize_version }}
+            **UI**: ${{ steps.current-versions.outputs.current_ui_version }} → ${{ steps.fetch-ui-version.outputs.ui_version }}
+            
+            - Images verified on quay.io ✓
+          branch: automated/update-kruize-versions-${{ github.run_number }}
+          delete-branch: true
+          labels: |
+            automated
+            dependencies
+            kruize-version-update
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Kruize Version Sync Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Autotune" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version (pom.xml):** ${{ steps.fetch-autotune-version.outputs.kruize_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Current Version (constants):** ${{ steps.current-versions.outputs.current_autotune_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image Available:** ${{ steps.check-autotune-image.outputs.image_available }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Update Needed:** ${{ steps.update-check.outputs.needs_autotune_update }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### UI" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version (package.json):** ${{ steps.fetch-ui-version.outputs.ui_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Current Version (constants):** ${{ steps.current-versions.outputs.current_ui_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image Available:** ${{ steps.check-ui-image.outputs.image_available }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Update Needed:** ${{ steps.update-check.outputs.needs_ui_update }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Overall" >> $GITHUB_STEP_SUMMARY
+          echo "- **Any Update Needed:** ${{ steps.update-check.outputs.needs_update }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Generate token from GitHub App
         id: generate-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout kruize-operator repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -189,9 +189,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: "build(deps): update Kruize versions to Autotune ${{ steps.fetch-autotune-version.outputs.kruize_version }} and UI ${{ steps.fetch-ui-version.outputs.ui_version }}"
           title: "build(deps): update Kruize image versions"
-          committer: kruize-version-sync <${{ secrets.APP_ID }}+kruize-version-sync@users.noreply.github.com>
-          author: kruize-version-sync <${{ secrets.APP_ID }}+kruize-version-sync@users.noreply.github.com>
-          sign-commits: true
           body: |
             ## Automated Version Update
             

--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -29,16 +29,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
+      - name: Install XML parsing tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends libxml2-utils
 
       - name: Fetch Kruize Autotune version from master branch
         id: fetch-autotune-version
         run: |
-          # Fetch the pom.xml from kruize/autotune master branch
-          KRUIZE_VERSION=$(curl -s https://raw.githubusercontent.com/kruize/autotune/master/pom.xml | grep -oP '<version>\K[^<]+' | head -1)
+          # Fetch the pom.xml from kruize/autotune master branch and extract /project/version
+          KRUIZE_VERSION=$(
+            curl -s https://raw.githubusercontent.com/kruize/autotune/master/pom.xml \
+            | xmllint --xpath 'string(/project/version)' - 2>/dev/null
+          )
           
           if [ -z "$KRUIZE_VERSION" ]; then
             echo "Failed to fetch Kruize Autotune version from pom.xml"
@@ -80,11 +83,15 @@ jobs:
               echo "Autotune image tag $KRUIZE_VERSION is available on quay.io"
             else
               echo "image_available=false" >> $GITHUB_OUTPUT
-              echo "Autotune image tag $KRUIZE_VERSION not found on quay.io"
+              echo "Autotune image tag $KRUIZE_VERSION not found on quay.io (HTTP 200, tag missing)"
             fi
+          elif [ "$HTTP_CODE" -eq 404 ]; then
+            echo "image_available=false" >> $GITHUB_OUTPUT
+            echo "Autotune image tag $KRUIZE_VERSION not found on quay.io (HTTP 404)"
           else
             echo "image_available=false" >> $GITHUB_OUTPUT
-            echo "Failed to check Autotune image availability (HTTP $HTTP_CODE)"
+            echo "Error checking Autotune image availability on quay.io (HTTP $HTTP_CODE)"
+            exit 1
           fi
 
       - name: Check Quay.io for UI image tag availability


### PR DESCRIPTION
This PR adds a GitHub workflow to sync and update Kruize and Kruize UI image versions based on the upstream repository updates.

## Summary by Sourcery

Automate synchronization of Kruize Autotune and UI image versions with their upstream repositories via a scheduled workflow that updates local defaults when new, available images are detected.

CI:
- Add a scheduled and manually-triggerable GitHub Actions workflow to fetch Kruize Autotune and UI versions from upstream, verify corresponding Quay.io images, compare against local constants, and summarize the results.
- Automatically open pull requests that update Kruize image version constants and sample manifests when upstream versions change and images are available.