### PR TITLE
Enable kruize-sync-version workflow on mvp_demo

### DIFF
--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -1,6 +1,11 @@
 name: Sync Kruize Versions
 
 on:
+  push:
+    branches:
+      - mvp_demo
+    paths:
+      - '.github/workflows/sync-kruize-versions.yml'
   schedule:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'


### PR DESCRIPTION
Currently newly added workflow - `Sync Kruize Versions` will be appeared under Actions tab only after merging to `main` branch. To test the workflow this PR enables it to be triggered on push to `mvp_demo` branch.

## Summary by Sourcery

CI:
- Trigger the Sync Kruize Versions GitHub Actions workflow on pushes to the mvp_demo branch when its workflow file is modified.