### PR TITLE
Update branch name prefix in GH workflow

### DIFF
--- a/.github/workflows/sync-kruize-versions.yml
+++ b/.github/workflows/sync-kruize-versions.yml
@@ -203,7 +203,7 @@ jobs:
         run: |
           set -euo pipefail
           
-          BRANCH_NAME="automated/v2-gh-api-kruize-versions-${{ github.run_number }}-${{ github.run_attempt }}"
+          BRANCH_NAME="automated/bump-kruize-versions-${{ github.run_number }}-${{ github.run_attempt }}"
           REPO="${{ github.repository }}"
           BASE_BRANCH="${{ github.ref_name }}"
           


### PR DESCRIPTION
This PR updates branch name prefix to `bump-kruize-versions` in Sync Kruize Versions GitHub workflow

## Summary by Sourcery

Build:
- Change the auto-generated branch name prefix in the sync-kruize-versions workflow to `automated/bump-kruize-versions`.