### PR TITLE
Update RH UBI image version to 10.1-1774545417

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY internal/constants/ internal/constants/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /tmp/manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417
 WORKDIR /app
 
 COPY --from=builder /tmp/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY internal/constants/ internal/constants/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /tmp/manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1770180557
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
 WORKDIR /app
 
 COPY --from=builder /tmp/manager .

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1770180557
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1772441549
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1774545417
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
Updated RH UBI minimal version to latest available - 10.1-1774545417

## Summary by Sourcery

Build:
- Bump Red Hat UBI 10 minimal base image tag to 10.1-1772441549 in runtime and bundle Dockerfiles.