### PR TITLE
Adding Optimizer Integration

### DIFF
--- a/api/v1alpha1/kruize_types.go
+++ b/api/v1alpha1/kruize_types.go
@@ -40,6 +40,10 @@ type KruizeSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autotune UI Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Autotune_ui_image string `json:"autotune_ui_image"`
 
+	// Container image for Kruize Optimizer
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Optimizer Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Optimizer_image   string `json:"optimizer_image,omitempty"`
+
 	// Target namespace for Kruize deployment
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace         string `json:"namespace"`

--- a/config/crd/bases/kruize.io_kruizes.yaml
+++ b/config/crd/bases/kruize.io_kruizes.yaml
@@ -151,6 +151,9 @@ spec:
               namespace:
                 description: Target namespace for Kruize deployment
                 type: string
+              optimizer_image:
+                description: Container image for Kruize Optimizer
+                type: string
               persistentVolume:
                 description: Persistent Volume configuration
                 properties:

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -10,7 +10,7 @@ spec:
   cluster_type: "openshift"
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
-  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1_mvp"
+  optimizer_image: "quay.io/kruize/kruize-optimizer:0.0.1"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,14 +8,9 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
-<<<<<<< HEAD
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
-=======
-  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
-  autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
-  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1-test"
->>>>>>> 440171c (adding optimizer integration)
+  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1_mvp"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,8 +8,14 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
+<<<<<<< HEAD
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
+=======
+  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
+  autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
+  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1-test"
+>>>>>>> 440171c (adding optimizer integration)
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -39,7 +39,7 @@ const (
 	defaultUIImageTag = "0.1.0"
 	
 	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
-	defaultOptimizerImageTag = "0.1_mvp"
+	defaultOptimizerImageTag = "0.0.1"
 	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -48,7 +48,7 @@ const (
 	defaultUIImageRepo = "quay.io/kruize/kruize-ui"
 	
 	// defaultOptimizerImageRepo is the default repository for Kruize Optimizer image
-	defaultOptimizerImageRepo = "quay.io/rh-ee-shesaxen/optimizer"
+	defaultOptimizerImageRepo = "quay.io/kruize/kruize-optimizer"
 )
 
 // Package-level variables that cache the resolved default images.

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -39,7 +39,7 @@ const (
 	defaultUIImageTag = "0.1.0"
 	
 	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
-	defaultOptimizerImageTag = "0.1-test"
+	defaultOptimizerImageTag = "0.1_mvp"
 	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -25,6 +25,9 @@ const (
 	
 	// envUIImage is the environment variable name for overriding the default Kruize UI image
 	envUIImage = "DEFAULT_AUTOTUNE_UI_IMAGE"
+	
+	// envOptimizerImage is the environment variable name for overriding the default Optimizer image
+	envOptimizerImage = "DEFAULT_OPTIMIZER_IMAGE"
 )
 
 // Default container image versions
@@ -35,11 +38,17 @@ const (
 	// defaultUIImageTag is the default tag for Kruize UI image
 	defaultUIImageTag = "0.1.0"
 	
+	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
+	defaultOptimizerImageTag = "0.1-test"
+	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
 	
 	// defaultUIImageRepo is the default repository for Kruize UI image
 	defaultUIImageRepo = "quay.io/kruize/kruize-ui"
+	
+	// defaultOptimizerImageRepo is the default repository for Kruize Optimizer image
+	defaultOptimizerImageRepo = "quay.io/rh-ee-shesaxen/optimizer"
 )
 
 // Package-level variables that cache the resolved default images.
@@ -47,7 +56,8 @@ const (
 // environment variable lookups on every function call.
 var (
 	defaultAutotuneImage   string
-	defaultUIImage string
+	defaultUIImage         string
+	defaultOptimizerImage  string
 )
 
 // init resolves the default images by checking environment variables once at package initialization.
@@ -66,6 +76,13 @@ func init() {
 	} else {
 		defaultUIImage = defaultUIImageRepo + ":" + defaultUIImageTag
 	}
+	
+	// Resolve Optimizer image
+	if envImage := os.Getenv(envOptimizerImage); envImage != "" {
+		defaultOptimizerImage = envImage
+	} else {
+		defaultOptimizerImage = defaultOptimizerImageRepo + ":" + defaultOptimizerImageTag
+	}
 }
 
 // GetDefaultAutotuneImage returns the cached default Autotune image.
@@ -78,4 +95,10 @@ func GetDefaultAutotuneImage() string {
 // The image is resolved once at package initialization from environment variables or defaults.
 func GetDefaultUIImage() string {
 	return defaultUIImage
+}
+
+// GetDefaultOptimizerImage returns the cached default Optimizer image.
+// The image is resolved once at package initialization from environment variables or defaults.
+func GetDefaultOptimizerImage() string {
+	return defaultOptimizerImage
 }

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -194,6 +194,53 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 	}
 }
 
+// waitForKruizeDeploymentReady waits specifically for the Kruize deployment to be ready
+// before proceeding with optimizer deployment
+func (r *KruizeReconciler) waitForKruizeDeploymentReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	logger := log.FromContext(ctx)
+
+	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
+
+	timeoutCh := time.After(timeout)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCh:
+			return fmt.Errorf("timeout waiting for Kruize deployment to be ready in namespace %s", namespace)
+
+		case <-ticker.C:
+			// Check if kruize deployment exists and is ready
+			deployment := &appsv1.Deployment{}
+			err := r.Get(ctx, client.ObjectKey{
+				Namespace: namespace,
+				Name:      "kruize",
+			}, deployment)
+
+			if err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("Kruize deployment not found yet, waiting...", "namespace", namespace)
+					continue
+				}
+				logger.Error(err, "Failed to get Kruize deployment")
+				continue
+			}
+
+			// Check if deployment is ready
+			if deployment.Status.ReadyReplicas > 0 && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
+				logger.Info("Kruize deployment is ready", "namespace", namespace, "readyReplicas", deployment.Status.ReadyReplicas)
+				return nil
+			}
+
+			logger.Info("Waiting for Kruize deployment to be ready",
+				"namespace", namespace,
+				"readyReplicas", deployment.Status.ReadyReplicas,
+				"desiredReplicas", deployment.Status.Replicas)
+		}
+	}
+}
+
 func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace string) (int, int, map[string]string, error) {
 	podList := &corev1.PodList{}
 	err := r.Client.List(ctx, podList, client.InNamespace(namespace))
@@ -327,15 +374,43 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		return err
 	}
 
-	// Reconcile namespace-scoped resources (WITH owner reference)
-	for _, obj := range namespacedObjects {
+	// Deploy core Kruize resources (DB, Kruize, UI) without optimizer
+	var coreResources []client.Object
+	var optimizerResources []client.Object
+
+	if clusterType == constants.ClusterTypeOpenShift {
+		coreResources = k8sObjectGenerator.CoreNamespacedResources()
+		optimizerResources = k8sObjectGenerator.OptimizerNamespacedResources()
+	} else {
+		coreResources = k8sObjectGenerator.CoreKubernetesNamespacedResources()
+		optimizerResources = k8sObjectGenerator.OptimizerKubernetesNamespacedResources()
+	}
+
+	logger.Info("Deploying core Kruize resources", "namespace", namespace)
+	for _, obj := range coreResources {
 		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
-			logger.Error(err, "Failed to reconcile namespaced resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
+			logger.Error(err, "Failed to reconcile core resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
 			return err
 		}
 	}
 
-	logger.Info("Successfully reconciled all dependent resources", "clusterType", clusterType)
+	// Wait for Kruize deployment to be ready
+	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
+	if err := r.waitForKruizeDeploymentReady(ctx, namespace, 3*time.Minute); err != nil {
+		logger.Error(err, "Kruize deployment not ready, will retry")
+		return err
+	}
+
+	// Deploy optimizer resources after Kruize is ready
+	logger.Info("Kruize is ready, now deploying optimizer", "namespace", namespace)
+	for _, obj := range optimizerResources {
+		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
+			logger.Error(err, "Failed to reconcile optimizer resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
+			return err
+		}
+	}
+
+	logger.Info("Successfully reconciled all dependent resources in phases", "clusterType", clusterType)
 	return nil
 }
 

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -161,7 +161,7 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 		return nil
 	}
 
-	requiredPods := []string{"kruize", "kruize-ui-nginx", "kruize-db"}
+	requiredPods := []string{"kruize", "kruize-ui-nginx", "kruize-db", "kruize-optimizer"}
 	logger.Info("Waiting for Kruize pods to be ready", "namespace", namespace, "pods", requiredPods)
 
 	timeoutCh := time.After(timeout)
@@ -183,8 +183,8 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 			logger.Info("Pod status check", "ready", readyPods, "total", totalPods, "namespace", namespace)
 			fmt.Printf("Pod status: %v\n", podStatus)
 
-			// Check if we have all required pods running
-			if readyPods >= 3 && totalPods >= 3 {
+			// Check if we have all required pods running (kruize, kruize-ui-nginx, kruize-db, kruize-optimizer)
+			if readyPods >= 4 && totalPods >= 4 {
 				logger.Info("All Kruize pods are ready", "readyPods", readyPods)
 				return nil
 			}
@@ -244,7 +244,8 @@ func (r *KruizeReconciler) deployKruize(ctx context.Context, kruize *kruizev1alp
 		"cluster_type", kruize.Spec.Cluster_type,
 		"namespace", kruize.Spec.Namespace,
 		"autotune_image", kruize.Spec.Autotune_image,
-		"autotune_ui_image", kruize.Spec.Autotune_ui_image)
+		"autotune_ui_image", kruize.Spec.Autotune_ui_image,
+		"optimizer_image", kruize.Spec.Optimizer_image)
 
 	// Normalize and validate cluster type (case-insensitive)
 	cluster_type := kruize.Spec.Cluster_type
@@ -282,6 +283,7 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		namespace,
 		kruize.Spec.Autotune_image,
 		kruize.Spec.Autotune_ui_image,
+		kruize.Spec.Optimizer_image,
 		clusterType,
 		&kruize.Spec,
 		ctx,

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -195,52 +195,6 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 	}
 }
 
-// waitForKruizeDeploymentReady waits specifically for the Kruize deployment to be ready
-// before proceeding with optimizer deployment
-func (r *KruizeReconciler) waitForKruizeDeploymentReady(ctx context.Context, namespace string, timeout time.Duration) error {
-	logger := log.FromContext(ctx)
-
-	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
-
-	timeoutCh := time.After(timeout)
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-timeoutCh:
-			return fmt.Errorf("timeout waiting for Kruize deployment to be ready in namespace %s", namespace)
-
-		case <-ticker.C:
-			// Check if kruize deployment exists and is ready
-			deployment := &appsv1.Deployment{}
-			err := r.Get(ctx, client.ObjectKey{
-				Namespace: namespace,
-				Name:      "kruize",
-			}, deployment)
-
-			if err != nil {
-				if errors.IsNotFound(err) {
-					logger.Info("Kruize deployment not found yet, waiting...", "namespace", namespace)
-					continue
-				}
-				logger.Error(err, "Failed to get Kruize deployment")
-				continue
-			}
-
-			// Check if deployment is ready
-			if deployment.Status.ReadyReplicas > 0 && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-				logger.Info("Kruize deployment is ready", "namespace", namespace, "readyReplicas", deployment.Status.ReadyReplicas)
-				return nil
-			}
-
-			logger.Info("Waiting for Kruize deployment to be ready",
-				"namespace", namespace,
-				"readyReplicas", deployment.Status.ReadyReplicas,
-				"desiredReplicas", deployment.Status.Replicas)
-		}
-	}
-}
 
 func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace string) (int, int, map[string]string, error) {
 	podList := &corev1.PodList{}
@@ -392,15 +346,9 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		}
 	}
 
-	// Wait for Kruize deployment to be ready
-	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
-	if err := r.waitForKruizeDeploymentReady(ctx, namespace, 3*time.Minute); err != nil {
-		logger.Error(err, "Kruize deployment not ready, will retry")
-		return err
-	}
-
-	// Deploy optimizer resources after Kruize is ready
-	logger.Info("Kruize is ready, now deploying optimizer", "namespace", namespace)
+	// Deploy optimizer resources with init container that waits for Kruize
+	// The init container in the optimizer deployment will handle waiting for Kruize to be ready
+	logger.Info("Deploying optimizer resources (init container will wait for Kruize to be ready)", "namespace", namespace)
 	for _, obj := range optimizerResources {
 		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
 			logger.Error(err, "Failed to reconcile optimizer resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -339,25 +340,22 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 
 	// Reconcile cluster-scoped resources based on cluster type
 	var clusterScopedObjects []client.Object
-	var namespacedObjects []client.Object
 	var configmap client.Object
 
 	if clusterType == constants.ClusterTypeOpenShift {
 		// OpenShift-specific resources
-        	kruizeServiceAccount := k8sObjectGenerator.KruizeServiceAccount()
-        	if err := r.reconcileClusterResource(ctx, kruizeServiceAccount); err != nil {
-            		logger.Error(err, "Failed to reconcile kruize service account")
-            		return err
-        	}
+	       	kruizeServiceAccount := k8sObjectGenerator.KruizeServiceAccount()
+	       	if err := r.reconcileClusterResource(ctx, kruizeServiceAccount); err != nil {
+	           		logger.Error(err, "Failed to reconcile kruize service account")
+	           		return err
+	       	}
 
 		clusterScopedObjects = k8sObjectGenerator.ClusterScopedResources()
 		configmap = k8sObjectGenerator.KruizeConfigMap()
-		namespacedObjects = k8sObjectGenerator.NamespacedResources()
 	} else {
 		// Kind/Minikube-specific resources
 		clusterScopedObjects = k8sObjectGenerator.KubernetesClusterScopedResources()
 		configmap = k8sObjectGenerator.KruizeConfigMapKubernetes()
-		namespacedObjects = k8sObjectGenerator.KubernetesNamespacedResources()
 	}
 
 	// Reconcile cluster-scoped resources (no owner reference)

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -460,40 +460,35 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Resource generation", func() {
 		It("should generate cluster-scoped resources for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			clusterResources := generator.ClusterScopedResources()
 			Expect(clusterResources).NotTo(BeEmpty())
 			Expect(len(clusterResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate namespaced resources for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.NamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate Kubernetes cluster-scoped resources", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			clusterResources := generator.KubernetesClusterScopedResources()
 			Expect(clusterResources).NotTo(BeEmpty())
 			Expect(len(clusterResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate Kubernetes namespaced resources", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.KubernetesNamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should use default images when not specified", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			Expect(generator.Autotune_image).To(Equal(constants.GetDefaultAutotuneImage()))
 			Expect(generator.Autotune_ui_image).To(Equal(constants.GetDefaultUIImage()))
 		})
@@ -501,7 +496,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should use custom images when specified", func() {
 			customImage := "custom/image:v1.0"
 			customUIImage := "custom/ui:v1.0"
-			generator := utils.NewKruizeResourceGenerator("test-namespace", customImage, customUIImage, constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			customOptimizerImage := "custom/optimizer:v1.0"
+
+			generator := utils.NewKruizeResourceGenerator("test-namespace", customImage, customUIImage, customOptimizerImage, constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			Expect(generator.Autotune_image).To(Equal(customImage))
 			Expect(generator.Autotune_ui_image).To(Equal(customUIImage))
@@ -605,7 +602,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("RBAC and ConfigMap manifest generation", func() {
 		It("should generate RBAC manifests correctly for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -626,7 +623,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate RBAC manifests correctly for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -647,7 +645,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate ConfigMap correctly for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMap()
 			Expect(configMap).NotTo(BeNil())
@@ -657,8 +655,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate ConfigMap correctly for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			configMap := generator.KruizeConfigMapKubernetes()
 			Expect(configMap).NotTo(BeNil())
 			Expect(configMap.GetName()).To(Equal("kruizeconfig"))
@@ -669,7 +666,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Data source configuration validation", func() {
 		It("should have valid data source configuration in ConfigMap for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMap()
 			Expect(configMap.Data).To(HaveKey("kruizeconfigjson"))
@@ -680,7 +677,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should have valid data source configuration in ConfigMap for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMapKubernetes()
 			Expect(configMap.Data).To(HaveKey("kruizeconfigjson"))
@@ -694,7 +691,8 @@ var _ = Describe("Kruize Controller", func() {
 	Context("Kruize deployment manifest generation", func() {
 		DescribeTable("should generate valid Kruize deployment manifest with default resources",
 			func(clusterType string, resourceMethod func(*utils.KruizeResourceGenerator) []client.Object) {
-				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 				namespacedResources := resourceMethod(generator)
 
 				// Check for Deployment resources and validate default resource configuration
@@ -790,7 +788,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Pod creation validation", func() {
 		It("should generate Kruize pod specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -800,7 +798,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-ui deployment specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext()))
 
 			namespacedResources := generator.NamespacedResources()
 			
@@ -820,7 +818,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-db pod specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -833,7 +831,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("1.0", "2.0", "1Gi", "2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -854,7 +852,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("0.25", "1.0", "256Mi", "512Mi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -872,7 +870,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default resources when ResourceConfig is nil", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "",constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -893,7 +891,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("1.5", "", "", "3Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -918,7 +916,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("0.3", "", "", ""),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -938,7 +936,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("", "", "", "2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			namespacedResources := generator.KubernetesNamespacedResources()
 
@@ -958,7 +956,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("", "1.0", "256Mi", ""),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			namespacedResources := generator.KubernetesNamespacedResources()
 
@@ -983,7 +981,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume:      createPVSpec("2Gi", "custom-storage", "/custom/path", []kruizev1alpha1.PersistentVolumeAccessMode{kruizev1alpha1.ReadWriteOnce}),
 				PersistentVolumeClaim: createPVCSpec("1Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -1008,7 +1006,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume:      createPVSpec("3Gi", "k8s-storage", "/k8s/custom/path", []kruizev1alpha1.PersistentVolumeAccessMode{kruizev1alpha1.ReadWriteMany}),
 				PersistentVolumeClaim: createPVCSpec("2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1033,7 +1031,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume: createPVSpec("5Gi", "fallback-storage", "/fallback/path", nil),
 				// PVC not specified, should use PV storage size
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -1054,7 +1052,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume: createPVSpec("4Gi", "k8s-fallback", "/k8s/fallback", nil),
 				// PVC not specified, should use PV storage size
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1071,7 +1069,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default PV/PVC configuration when ResourceConfig is nil for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -1092,7 +1090,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default PV/PVC configuration when ResourceConfig is nil for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1115,8 +1113,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Route and service creation", func() {
 		It("should generate routes for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.NamespacedResources()
 
 			// Check for Route resources
@@ -1138,7 +1135,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate services for all cluster types", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1167,7 +1164,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Kruize endpoints validation", func() {
 		It("should generate service with correct ports for Kruize", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1188,7 +1185,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate service with correct ports for Kruize UI", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1209,7 +1207,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate service with correct ports for Kruize DB", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1230,7 +1229,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize service with NodePort type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1241,7 +1240,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize UI service with NodePort type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1252,7 +1251,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize DB service with ClusterIP type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1269,7 +1268,8 @@ var _ = Describe("Kruize Controller", func() {
     		clusterType := constants.ClusterTypeMinikube
 
     		By("creating a generator with empty image fields")
-    		generator := utils.NewKruizeResourceGenerator(namespace, "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+    		generator := utils.NewKruizeResourceGenerator(namespace, "", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
     		By("verifying the generator uses the default-image helpers")
     		// This test verifies that the generator is wired to use the default-image helpers
@@ -1309,9 +1309,11 @@ var _ = Describe("Kruize Controller", func() {
     		clusterType := constants.ClusterTypeMinikube
     		customAutotuneImage := "custom.registry/autotune:custom-tag"
     		customUIImage := "custom.registry/ui:custom-tag"
+			customOptimizerImage := "custom.registry/optimizer:custom-tag"
 
     		By("creating a generator with custom image values")
-    		generator := utils.NewKruizeResourceGenerator(namespace, customAutotuneImage, customUIImage, clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+    		generator := utils.NewKruizeResourceGenerator(namespace, customAutotuneImage, customUIImage, customOptimizerImage, clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
     		By("verifying the generator uses the provided custom images")
     		Expect(generator.Autotune_image).To(Equal(customAutotuneImage),

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -521,7 +521,7 @@ var _ = Describe("Kruize Controller", func() {
 				},
 			}
 
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
@@ -551,7 +551,7 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should allow partial resource overrides while preserving defaults", func() {
 			// First, generate resources with default configuration to capture default resources
-			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			defaultNamespacedResources := defaultGenerator.NamespacedResources()
 
 			defaultKruizeDeployment := findDeployment(defaultNamespacedResources, "kruize")
@@ -570,7 +570,7 @@ var _ = Describe("Kruize Controller", func() {
 				KruizeDB: createKruizeDBConfig("250m", "", "", ""),
 				Kruize:   createKruizeAppConfig("300m", "", "", ""),
 			}
-			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
+			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
 			partialNamespacedResources := partialGenerator.NamespacedResources()
 
 			partialKruizeDeployment := findDeployment(partialNamespacedResources, "kruize")
@@ -753,7 +753,7 @@ var _ = Describe("Kruize Controller", func() {
 					Kruize:   createKruizeAppConfig("2.0", "2.5", "1Gi", "1.5Gi"),
 					KruizeDB: createKruizeDBConfig("0.75", "1.5", "512Mi", "1Gi"),
 				}
-				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", clusterType, customSpec, getTestContext())
+				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", clusterType, customSpec, getTestContext())
 				namespacedResources := resourceMethod(generator)
 
 				// Check for Deployment resources and validate custom resource configuration
@@ -798,7 +798,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-ui deployment specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext()))
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 			

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -468,7 +468,9 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should generate namespaced resources for OpenShift", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
@@ -482,7 +484,9 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should generate Kubernetes namespaced resources", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
@@ -523,7 +527,9 @@ var _ = Describe("Kruize Controller", func() {
 
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -552,7 +558,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should allow partial resource overrides while preserving defaults", func() {
 			// First, generate resources with default configuration to capture default resources
 			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			defaultNamespacedResources := defaultGenerator.NamespacedResources()
+			defaultCoreResources := defaultGenerator.CoreNamespacedResources()
+			defaultOptimizerResources := defaultGenerator.OptimizerNamespacedResources()
+			defaultNamespacedResources := append(defaultCoreResources, defaultOptimizerResources...)
 
 			defaultKruizeDeployment := findDeployment(defaultNamespacedResources, "kruize")
 			defaultDBDeployment := findDeployment(defaultNamespacedResources, "kruize-db-deployment")
@@ -571,7 +579,9 @@ var _ = Describe("Kruize Controller", func() {
 				Kruize:   createKruizeAppConfig("300m", "", "", ""),
 			}
 			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
-			partialNamespacedResources := partialGenerator.NamespacedResources()
+			partialCoreResources := partialGenerator.CoreNamespacedResources()
+			partialOptimizerResources := partialGenerator.OptimizerNamespacedResources()
+			partialNamespacedResources := append(partialCoreResources, partialOptimizerResources...)
 
 			partialKruizeDeployment := findDeployment(partialNamespacedResources, "kruize")
 			partialDBDeployment := findDeployment(partialNamespacedResources, "kruize-db-deployment")
@@ -740,10 +750,14 @@ var _ = Describe("Kruize Controller", func() {
 				}
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.NamespacedResources()
+				coreResources := g.CoreNamespacedResources()
+				optimizerResources := g.OptimizerNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 			Entry("for Kubernetes", constants.ClusterTypeMinikube, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.KubernetesNamespacedResources()
+				coreResources := g.CoreKubernetesNamespacedResources()
+				optimizerResources := g.OptimizerKubernetesNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 		)
 
@@ -778,10 +792,14 @@ var _ = Describe("Kruize Controller", func() {
 				Expect(dbContainer.Resources.Limits.Memory().String()).To(Equal("1Gi"))
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.NamespacedResources()
+				coreResources := g.CoreNamespacedResources()
+				optimizerResources := g.OptimizerNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 			Entry("for Kubernetes", constants.ClusterTypeMinikube, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.KubernetesNamespacedResources()
+				coreResources := g.CoreKubernetesNamespacedResources()
+				optimizerResources := g.OptimizerKubernetesNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 		)
 	})
@@ -790,7 +808,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize pod specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -800,7 +820,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize-ui deployment specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			
 			// Find the Kruize UI deployment
 			var kruizeUIDeployment *appsv1.Deployment
@@ -820,7 +842,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize-db pod specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -833,7 +857,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -854,7 +880,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -872,7 +900,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should use default resources when ResourceConfig is nil", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "",constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -893,7 +923,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -918,7 +950,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -938,7 +972,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -958,7 +994,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -1114,7 +1152,9 @@ var _ = Describe("Kruize Controller", func() {
 	Context("Route and service creation", func() {
 		It("should generate routes for OpenShift", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Check for Route resources
 			var hasKruizeRoute, hasUIRoute bool
@@ -1137,7 +1177,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate services for all cluster types", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Check for Service resources
 			var hasKruizeService, hasDBService, hasUIService bool
@@ -1166,7 +1208,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate service with correct ports for Kruize", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize service
 			kruizeService := findTypedResource[*corev1.Service](namespacedResources, "kruize", "", "")
@@ -1188,7 +1232,9 @@ var _ = Describe("Kruize Controller", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize UI service
 			kruizeUIService := findTypedResource[*corev1.Service](namespacedResources, "kruize-ui-nginx-service", "", "")
@@ -1210,7 +1256,9 @@ var _ = Describe("Kruize Controller", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB service
 			kruizeDBService := findTypedResource[*corev1.Service](namespacedResources, "kruize-db-service", "", "")
@@ -1231,7 +1279,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize service with NodePort type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize service
 			kruizeService := findTypedResource[*corev1.Service](namespacedResources, "kruize", "", "")
@@ -1242,7 +1292,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize UI service with NodePort type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize UI service
 			kruizeUIService := findTypedResource[*corev1.Service](namespacedResources, "kruize-ui-nginx-service", "", "")
@@ -1253,7 +1305,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize DB service with ClusterIP type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB service
 			kruizeDBService := findTypedResource[*corev1.Service](namespacedResources, "kruize-db-service", "", "")
@@ -1279,7 +1333,9 @@ var _ = Describe("Kruize Controller", func() {
     			"Generator should default Autotune_ui_image when empty")
 
     		By("verifying the generated resources use default images")
-    		namespacedResources := generator.KubernetesNamespacedResources()
+    		coreResources := generator.CoreKubernetesNamespacedResources()
+    		optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+    		namespacedResources := append(coreResources, optimizerResources...)
 
     		// Find and verify Kruize deployment using helper
     		kruizeDeployment := findTypedResource[*appsv1.Deployment](namespacedResources, "kruize", "app", "kruize")
@@ -1468,3 +1524,4 @@ var _ = Describe("Kruize Controller", func() {
         })
     })
 })
+

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -1115,6 +1115,23 @@ func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment
 					},
 				},
 				Spec: corev1.PodSpec{
+					// Init container to wait for Kruize deployment to be ready
+					InitContainers: []corev1.Container{
+						{
+							Name:  "wait-for-kruize",
+							Image: "busybox:1.36",
+							Command: []string{
+								"sh",
+								"-c",
+								`echo "Waiting for Kruize service to be ready...";
+								until wget -q -O- --timeout=5 http://kruize:8080/health >/dev/null 2>&1 || wget -q -O- --timeout=5 http://kruize:8080 >/dev/null 2>&1; do
+								echo "Kruize service not ready yet, waiting...";
+								sleep 5;
+								done;
+								echo "Kruize service is ready!";`,
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "kruize-optimizer",

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-
 	kruizev1alpha1 "github.com/kruize/kruize-operator/api/v1alpha1"
 	"github.com/kruize/kruize-operator/internal/constants"
 	routev1 "github.com/openshift/api/route/v1"
@@ -1055,6 +1054,8 @@ func (g *KruizeResourceGenerator) kruizeService() *corev1.Service {
 			},
 		},
 	}
+}
+
 // kruizeOptimizerDeployment generates the Deployment for the Kruize Optimizer.
 func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment {
 	replicas := int32(1)
@@ -1141,9 +1142,6 @@ func (g *KruizeResourceGenerator) kruizeOptimizerService() *corev1.Service {
 		},
 	}
 }
-
-}
-
 
 func (g *KruizeResourceGenerator) kruizeUINginxDeployment() *appsv1.Deployment {
 	replicas := int32(1)

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -34,22 +34,27 @@ type KruizeResourceGenerator struct {
 	Namespace         string
 	Autotune_image    string
 	Autotune_ui_image string
+	Optimizer_image   string
 	ClusterType       string // "openshift", "minikube", or "kind"
 	KruizeSpec        *kruizev1alpha1.KruizeSpec
 	Ctx               context.Context
 }
 
 // NewKruizeResourceGenerator creates a new generator for Kruize resources.
-func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string, clusterType string, kruizeSpec *kruizev1alpha1.KruizeSpec, ctx context.Context) *KruizeResourceGenerator {
+func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string,  optimizerImage string, clusterType string, kruizeSpec *kruizev1alpha1.KruizeSpec, ctx context.Context) *KruizeResourceGenerator {
 	// If no image is provided from the CR, use a sensible default.
 	// The default can be configured via environment variables:
 	// - DEFAULT_AUTOTUNE_IMAGE: Override the default Autotune image
 	// - DEFAULT_AUTOTUNE_UI_IMAGE: Override the default Autotune UI image
+	// - DEFAULT_OPTIMIZER_IMAGE: Override the default Optimizer image
 	if autotuneImage == "" {
 		autotuneImage = constants.GetDefaultAutotuneImage()
 	}
 	if autotuneUIImage == "" {
 		autotuneUIImage = constants.GetDefaultUIImage()
+	}
+	if optimizerImage == "" {
+		optimizerImage = constants.GetDefaultOptimizerImage()
 	}
 	if clusterType == "" {
 		clusterType = constants.ClusterTypeOpenShift // Default to openshift for backward compatibility
@@ -58,6 +63,7 @@ func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotune
 		Namespace:         namespace,
 		Autotune_image:    autotuneImage,
 		Autotune_ui_image: autotuneUIImage,
+		Optimizer_image:   optimizerImage,
 		ClusterType:       clusterType,
 		KruizeSpec:        kruizeSpec,
 		Ctx:               ctx,
@@ -498,6 +504,8 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 		g.kruizeDBService(),
 		g.kruizeDeployment(),
 		g.kruizeService(),
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 		g.createPartitionCronJob(),
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
@@ -1047,6 +1055,93 @@ func (g *KruizeResourceGenerator) kruizeService() *corev1.Service {
 			},
 		},
 	}
+// kruizeOptimizerDeployment generates the Deployment for the Kruize Optimizer.
+func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment {
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kruize-optimizer",
+			Namespace: g.Namespace,
+			Labels: map[string]string{
+				"app": "kruize-optimizer",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "kruize-optimizer",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "kruize-optimizer",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "kruize-optimizer",
+							Image:           g.Optimizer_image,
+							ImagePullPolicy: corev1.PullAlways,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: 8080},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "ENABLE_SWAGGER", Value: "true"},
+								{Name: "KRUIZE_URL", Value: "http://kruize:8080"},
+								{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: "60m"},
+								{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: "15m"},
+								{Name: "KRUIZE_BULK_SCHEDULER_STARTUP_DELAY", Value: "1m"},
+								{Name: "KRUIZE_BULK_MEASUREMENT_DURATION", Value: "15min"},
+								{Name: "KRUIZE_WEBHOOK_URL", Value: "http://kruize-optimizer:8080/webhook"},
+								{Name: "KRUIZE_TARGET_LABEL_LIMIT", Value: "1"},
+								{Name: "KRUIZE_TARGET_LABELS", Value: `{"kruize/autotune": "enabled"}`},
+								{Name: "KRUIZE_DEFAULT_DATASOURCE", Value: "prometheus-1"},
+								{Name: "KRUIZE_DEFAULT_METADATA_PROFILE", Value: "cluster-metadata-local-monitoring"},
+								{Name: "KRUIZE_DEFAULT_METRIC_PROFILE", Value: "resource-optimization-local-monitoring"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// kruizeOptimizerService generates the Service for the Kruize Optimizer.
+func (g *KruizeResourceGenerator) kruizeOptimizerService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kruize-optimizer",
+			Namespace: g.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app": "kruize-optimizer",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	}
+}
+
 }
 
 
@@ -1896,6 +1991,8 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 		g.kruizeDBService(),
 		g.kruizeDeploymentKubernetes(),
 		g.kruizeServiceKubernetes(),
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 		g.createPartitionCronJob(),
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -494,29 +494,6 @@ func (g *KruizeResourceGenerator) ClusterScopedResources() []client.Object {
 	}
 }
 
-// NamespacedResources generates all OpenShift namespaced resources for Kruize.
-// These resources will get an owner reference set to the Kruize CR.
-func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
-	objects := []client.Object{
-		g.kruizeDBPersistentVolumeClaim(),
-		g.kruizeDBDeployment(),
-		g.kruizeDBService(),
-		g.kruizeDeployment(),
-		g.kruizeService(),
-		g.kruizeOptimizerDeployment(),
-		g.kruizeOptimizerService(),
-		g.createPartitionCronJob(),
-		g.kruizeServiceMonitor(),
-		g.nginxConfigMap(),
-		g.kruizeUINginxService(),
-		g.kruizeUINginxDeployment(),
-		g.deletePartitionCronJob(),
-	}
-
-	objects = append(objects, g.Routes()...)
-	return objects
-}
-
 // CoreNamespacedResources generates core Kruize resources (DB, Kruize, UI) without optimizer.
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
@@ -2023,26 +2000,6 @@ func (g *KruizeResourceGenerator) KubernetesClusterScopedResources() []client.Ob
 		g.instaslicesAccessClusterRoleBindingKubernetes(),
 		g.kruizeEditKOClusterRoleBindingKubernetes(),
 		g.kruizeDBPersistentVolumeKubernetes(),
-	}
-}
-
-// KubernetesNamespacedResources returns namespaced resources for Kind/minikube/Kubernetes
-func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Object {
-	return []client.Object{
-		g.kruizeDBPersistentVolumeClaimKubernetes(),
-		g.kruizeToPrometheusNetworkPolicy(),
-		g.kruizeDBDeploymentKubernetes(),
-		g.kruizeDBService(),
-		g.kruizeDeploymentKubernetes(),
-		g.kruizeServiceKubernetes(),
-		g.kruizeOptimizerDeployment(),
-		g.kruizeOptimizerService(),
-		g.createPartitionCronJob(),
-		g.kruizeServiceMonitor(),
-		g.nginxConfigMap(),
-		g.kruizeUINginxService(),
-		g.kruizeUINginxDeployment(),
-		g.deletePartitionCronJob(),
 	}
 }
 

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -529,7 +529,7 @@ func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
 		g.kruizeUINginxService(),
-		g.kruizeUINginxPod(),
+		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
 	}
 
@@ -2058,7 +2058,7 @@ func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.O
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
 		g.kruizeUINginxService(),
-		g.kruizeUINginxPod(),
+		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
 	}
 }

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -521,6 +521,7 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
 	objects := []client.Object{
+		g.kruizeDBPersistentVolumeClaim(),
 		g.kruizeDBDeployment(),
 		g.kruizeDBService(),
 		g.kruizeDeployment(),
@@ -2049,6 +2050,7 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.Object {
 	return []client.Object{
+		g.kruizeDBPersistentVolumeClaimKubernetes(),
 		g.kruizeToPrometheusNetworkPolicy(),
 		g.kruizeDBDeploymentKubernetes(),
 		g.kruizeDBService(),

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -517,6 +517,35 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 	return objects
 }
 
+// CoreNamespacedResources generates core Kruize resources (DB, Kruize, UI) without optimizer.
+// Deploy these first and wait for Kruize to be ready before deploying optimizer.
+func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
+	objects := []client.Object{
+		g.kruizeDBDeployment(),
+		g.kruizeDBService(),
+		g.kruizeDeployment(),
+		g.kruizeService(),
+		g.createPartitionCronJob(),
+		g.kruizeServiceMonitor(),
+		g.nginxConfigMap(),
+		g.kruizeUINginxService(),
+		g.kruizeUINginxPod(),
+		g.deletePartitionCronJob(),
+	}
+
+	objects = append(objects, g.Routes()...)
+	return objects
+}
+
+// OptimizerNamespacedResources generates optimizer-specific resources.
+// Deploy these after Kruize core is ready.
+func (g *KruizeResourceGenerator) OptimizerNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
+	}
+}
+
 func (g *KruizeResourceGenerator) Routes() []client.Object {
 	routes := []*routev1.Route{
 		g.generateRoute("kruize", "kruize", "kruize-port"),
@@ -1095,7 +1124,6 @@ func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment
 								{ContainerPort: 8080},
 							},
 							Env: []corev1.EnvVar{
-								{Name: "ENABLE_SWAGGER", Value: "true"},
 								{Name: "KRUIZE_URL", Value: "http://kruize:8080"},
 								{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: "60m"},
 								{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: "15m"},
@@ -1997,5 +2025,32 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 		g.kruizeUINginxService(),
 		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
+	}
+}
+
+// CoreKubernetesNamespacedResources returns core Kruize resources for Kubernetes without optimizer.
+// Deploy these first and wait for Kruize to be ready before deploying optimizer.
+func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeToPrometheusNetworkPolicy(),
+		g.kruizeDBDeploymentKubernetes(),
+		g.kruizeDBService(),
+		g.kruizeDeploymentKubernetes(),
+		g.kruizeServiceKubernetes(),
+		g.createPartitionCronJob(),
+		g.kruizeServiceMonitor(),
+		g.nginxConfigMap(),
+		g.kruizeUINginxService(),
+		g.kruizeUINginxPod(),
+		g.deletePartitionCronJob(),
+	}
+}
+
+// OptimizerKubernetesNamespacedResources returns optimizer-specific resources for Kubernetes.
+// Deploy these after Kruize core is ready.
+func (g *KruizeResourceGenerator) OptimizerKubernetesNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -332,6 +332,19 @@ var _ = Describe("controller", Ordered, func() {
 				return err
 			}, 3*time.Minute, 10*time.Second).Should(Succeed())
 
+			By("checking that Kruize Optimizer deployment is ready")
+			Eventually(func() error {
+				cmd := exec.Command("kubectl", "get", "deployment", "kruize-optimizer", "-n", namespace, "-o", "jsonpath={.status.readyReplicas}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return err
+				}
+				if string(output) != "1" {
+					return fmt.Errorf("kruize-optimizer deployment not ready")
+				}
+				return nil
+			}, 3*time.Minute, 10*time.Second).Should(Succeed())
+
 			By("checking that datasource is configured via Kruize API")
 			var datasourceOutput string
 			Eventually(func() error {


### PR DESCRIPTION
This PR integrates the Kruize Optimizer component into the Kruize operator, enabling advanced optimization capabilities alongside the existing Autotune functionality.

## Changes Made

### 1. **API Changes** (`api/v1alpha1/kruize_types.go`)
- Added `Optimizer_image` field to `KruizeSpec` to allow users to specify a custom Optimizer container image
- Field is optional with `omitempty` tag for backward compatibility

### 2. **Image Management** (`internal/constants/kruize_images.go`)
- Added support for Optimizer image configuration
- Introduced `DEFAULT_OPTIMIZER_IMAGE` environment variable for overriding default image
- Default image: `quay.io/rh-ee-shesaxen/optimizer:0.1-test`
- Added `GetDefaultOptimizerImage()` function for retrieving the configured image

### 3. **Resource Generation** (`internal/utils/kruize_generator.go`)
- Created `kruizeOptimizerDeployment()` to generate Optimizer deployment with:
  - Single replica configuration
  - Port 8080 exposure
  - Environment variables for Swagger, Kruize URL, scheduling intervals, webhook configuration, and datasource settings
- Created `kruizeOptimizerService()` to expose Optimizer on ClusterIP service
- Updated `NewKruizeResourceGenerator()` to accept and handle Optimizer image parameter
- Integrated Optimizer resources into both OpenShift and Kubernetes deployment flows

### 4. **Controller Updates** (`internal/controller/kruize_controller.go`)
- Updated pod readiness check to wait for 4 pods (added `kruize-optimizer` to the list)
- Modified deployment logging to include `optimizer_image` parameter
- Passed Optimizer image to resource generator

### 5. **Sample Configuration** (`config/samples/v1alpha1_kruize.yaml`)
- Added example `optimizer_image` configuration for reference

## Technical Details

**Optimizer Configuration:**
- **Image**: `quay.io/rh-ee-shesaxen/optimizer:0.1-test`
- **Port**: 8080
- **Key Features**:
  - Swagger UI enabled
  - Integration with Kruize service at `http://kruize:8080`
  - State refresh interval: 60 minutes
  - Bulk scheduler interval: 15 minutes
  - Webhook endpoint: `http://kruize-optimizer:8080/webhook`
  - Default datasource: `prometheus-1`
  - Target label filtering with `kruize/autotune: enabled`

## Summary by Sourcery

Integrate the Kruize Optimizer component into the operator and deployment flows alongside existing Autotune services.

New Features:
- Add configurable Optimizer container image to the Kruize custom resource spec with optional override.
- Introduce default Optimizer image resolution with environment variable override support.
- Create Kubernetes/OpenShift deployment and ClusterIP service resources for the Kruize Optimizer component.

Enhancements:
- Extend resource generator and controller wiring to propagate the Optimizer image and deploy the new component, including readiness checks for its pod.
- Update sample Kruize CR YAML to document usage of the new Optimizer image field.