### PR TITLE
Add operator and bundle build-push script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,15 +292,11 @@ operator-sdk: $(LOCALBIN) ## Download operator-sdk locally if necessary.
 		if ! command -v operator-sdk >/dev/null 2>&1; then \
 			echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
 			mkdir -p $(dir $(OPERATOR_SDK)) ;\
-			if command -v go >/dev/null 2>&1; then \
-				OS=$$(go env GOOS) && ARCH=$$(go env GOARCH) ;\
-			else \
-				OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
-				case $$ARCH in \
-					x86_64) ARCH=amd64 ;; \
-					aarch64) ARCH=arm64 ;; \
-				esac ;\
-			fi ;\
+			OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
+			case $$ARCH in \
+				x86_64) ARCH=amd64 ;; \
+				aarch64) ARCH=arm64 ;; \
+			esac ;\
 			curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 			chmod +x $(OPERATOR_SDK) ;\
 			echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\

--- a/Makefile
+++ b/Makefile
@@ -287,20 +287,29 @@ endef
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
-ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (, $(shell which operator-sdk 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-	chmod +x $(OPERATOR_SDK) ;\
-	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
-endif
+operator-sdk: $(LOCALBIN) ## Download operator-sdk locally if necessary.
+	@if [ ! -f $(OPERATOR_SDK) ]; then \
+		if ! command -v operator-sdk >/dev/null 2>&1; then \
+			echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
+			mkdir -p $(dir $(OPERATOR_SDK)) ;\
+			if command -v go >/dev/null 2>&1; then \
+				OS=$$(go env GOOS) && ARCH=$$(go env GOARCH) ;\
+			else \
+				OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
+				case $$ARCH in \
+					x86_64) ARCH=amd64 ;; \
+					aarch64) ARCH=arm64 ;; \
+				esac ;\
+			fi ;\
+			curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+			chmod +x $(OPERATOR_SDK) ;\
+			echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\
+		else \
+			echo "Using system operator-sdk: $$(which operator-sdk)" ;\
+		fi \
+	else \
+		echo "operator-sdk already exists at $(OPERATOR_SDK)" ;\
+	fi
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ See [Prerequisites](#prerequisites) section above for required tools and version
 
 `make catalog-build` will build an OCI image of the operator catalog.
 
+**Automated Build and Push Script:**
+
+For a streamlined build and push workflow with prerequisite checks and version management, use the provided script:
+
+```sh
+./scripts/operator_build_and_push.sh -o <operator_image> -b <bundle_image>
+```
+
+Example:
+```sh
+./scripts/operator_build_and_push.sh -o quay.io/kruize/kruize-operator:0.0.5 -b quay.io/kruize/kruize-operator-bundle:0.0.5
+```
+
+This script will:
+- Check prerequisites (including downloading operator-sdk if not available)
+- Update version files automatically
+- Build and push both operator and bundle images
+- Verify the images after pushing
+
+For more details, see [`scripts/operator_build_and_push.sh`](scripts/operator_build_and_push.sh).
+
 ## DEVELOPMENT
 
 Run the operator locally:

--- a/scripts/operator_build_and_push.sh
+++ b/scripts/operator_build_and_push.sh
@@ -116,18 +116,28 @@ check_prerequisites() {
     log_success "Prerequisites check passed"
 }
 
+# Helper function that works on both GNU (Linux) and BSD (macOS) sed
+# Usage: portable_sed_inplace "s/pattern/replacement/" file
+portable_sed_inplace() {
+    local pattern="$1"
+    local file="$2"
+
+    case "$OSTYPE" in
+        darwin*)
+            sed -i '' "$pattern" "$file"
+            ;;
+        *)
+            sed -i "$pattern" "$file"
+            ;;
+    esac
+}
+
 # Update Makefile version
 update_makefile_version() {
     log_info "Updating Makefile version to ${VERSION}..."
     
     if [[ -f "Makefile" ]]; then
-        # Use portable sed -i that works on both GNU (Linux) and BSD (macOS) sed
-        # GNU sed accepts -i without argument, BSD sed requires -i '' for no backup
-        if [[ "$OSTYPE" == "Darwin" ]]; then
-            sed -i '' "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
-        else
-            sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
-        fi
+        portable_sed_inplace "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
         log_success "Makefile version updated"
     else
         log_error "Makefile not found"
@@ -142,8 +152,8 @@ update_csv_version() {
     # Update bundle CSV file
     CSV_FILE="bundle/manifests/kruize-operator.clusterserviceversion.yaml"
     if [[ -f "$CSV_FILE" ]]; then
-        sed -i "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$CSV_FILE"
-        sed -i "s/name: kruize-operator\.v.*/name: kruize-operator.v${VERSION}/" "$CSV_FILE"
+        portable_sed_inplace "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$CSV_FILE"
+        portable_sed_inplace "s/name: kruize-operator\.v.*/name: kruize-operator.v${VERSION}/" "$CSV_FILE"
         log_success "Bundle CSV updated"
     else
         log_info "Bundle CSV not found (will be generated during bundle build)"
@@ -152,7 +162,7 @@ update_csv_version() {
     # Update base CSV file
     BASE_CSV_FILE="config/manifests/bases/kruize-operator.clusterserviceversion.yaml"
     if [[ -f "$BASE_CSV_FILE" ]]; then
-        sed -i "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$BASE_CSV_FILE"
+        portable_sed_inplace "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$BASE_CSV_FILE"
         log_success "Base CSV updated"
     else
         log_info "Base CSV not found"

--- a/scripts/operator_build_and_push.sh
+++ b/scripts/operator_build_and_push.sh
@@ -80,7 +80,8 @@ fi
 # Extract version from image tags
 extract_version() {
     local image=$1
-    echo ${image} | grep -oP ':\K[^:]+$'
+    # Use POSIX-compatible parameter expansion instead of grep -P
+    echo "${image##*:}"
 }
 
 OPERATOR_VERSION=$(extract_version "$OPERATOR_IMAGE")

--- a/scripts/operator_build_and_push.sh
+++ b/scripts/operator_build_and_push.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright (c) 2026, 2026 Red Hat, IBM Corporation and others.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Script to build and push operator and bundle images with verification
 # Usage: ./scripts/operator_build_and_push.sh -o <operator_image> -b <bundle_image>

--- a/scripts/operator_build_and_push.sh
+++ b/scripts/operator_build_and_push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to build and push operator and bundle images with verification
-# Usage: ./scripts/build-and-push-images.sh -o <operator_image> -b <bundle_image>
+# Usage: ./scripts/operator_build_and_push.sh -o <operator_image> -b <bundle_image>
 
 set -e  # Exit on error
 
@@ -32,10 +32,15 @@ usage() {
     echo "  -h    Show this help message"
     echo ""
     echo "Environment variables:"
-    echo "  CONTAINER_TOOL  Container tool to use (default: docker)"
+    echo "  CONTAINER_TOOL  Container tool to use for build, push, and verification (default: docker)"
+    echo "                  Supported values: docker, podman"
     echo ""
-    echo "Example:"
+    echo "Examples:"
+    echo "  # Using default docker"
     echo "  $0 -o quay.io/kruize/kruize-operator:0.0.5 -b quay.io/kruize/kruize-operator-bundle:0.0.5"
+    echo ""
+    echo "  # Using podman"
+    echo "  CONTAINER_TOOL=podman $0 -o quay.io/kruize/kruize-operator:0.0.5 -b quay.io/kruize/kruize-operator-bundle:0.0.5"
 }
 
 # Parse command line arguments
@@ -115,7 +120,13 @@ update_makefile_version() {
     log_info "Updating Makefile version to ${VERSION}..."
     
     if [[ -f "Makefile" ]]; then
-        sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+        # Use portable sed -i that works on both GNU (Linux) and BSD (macOS) sed
+        # GNU sed accepts -i without argument, BSD sed requires -i '' for no backup
+        if [[ "$OSTYPE" == "Darwin" ]]; then
+            sed -i '' "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+        else
+            sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+        fi
         log_success "Makefile version updated"
     else
         log_error "Makefile not found"
@@ -151,8 +162,8 @@ update_csv_version() {
 build_and_push_operator() {
     log_info "Building and pushing operator image: ${OPERATOR_IMAGE}"
     
-    log_info "Running: make docker-build docker-push IMG=${OPERATOR_IMAGE}"
-    make docker-build docker-push IMG=${OPERATOR_IMAGE}
+    log_info "Running: make docker-build docker-push IMG=${OPERATOR_IMAGE} CONTAINER_TOOL=${CONTAINER_TOOL}"
+    make docker-build docker-push IMG=${OPERATOR_IMAGE} CONTAINER_TOOL=${CONTAINER_TOOL}
     
     log_success "Operator image built and pushed: ${OPERATOR_IMAGE}"
 }
@@ -174,8 +185,8 @@ verify_operator_image() {
 build_and_push_bundle() {
     log_info "Building and pushing bundle image: ${BUNDLE_IMAGE}"
     
-    log_info "Running: make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE}"
-    make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE}
+    log_info "Running: make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE} CONTAINER_TOOL=${CONTAINER_TOOL}"
+    make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE} CONTAINER_TOOL=${CONTAINER_TOOL}
     
     log_success "Bundle image built and pushed: ${BUNDLE_IMAGE}"
 }

--- a/scripts/operator_build_and_push.sh
+++ b/scripts/operator_build_and_push.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+
+# Script to build and push operator and bundle images with verification
+# Usage: ./scripts/build-and-push-images.sh -o <operator_image> -b <bundle_image>
+
+set -e  # Exit on error
+
+# Default values
+OPERATOR_IMAGE=""
+BUNDLE_IMAGE=""
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+
+# Helper functions
+log_info() {
+    echo "[INFO] $1"
+}
+
+log_success() {
+    echo "[SUCCESS] $1"
+}
+
+log_error() {
+    echo "[ERROR] $1"
+}
+
+usage() {
+    echo "Usage: $0 -o <operator_image> -b <bundle_image>"
+    echo ""
+    echo "Options:"
+    echo "  -o    Operator image (e.g., quay.io/kruize/kruize-operator:0.0.4)"
+    echo "  -b    Bundle image (e.g., quay.io/kruize/kruize-operator-bundle:0.0.4)"
+    echo "  -h    Show this help message"
+    echo ""
+    echo "Environment variables:"
+    echo "  CONTAINER_TOOL  Container tool to use (default: docker)"
+    echo ""
+    echo "Example:"
+    echo "  $0 -o quay.io/kruize/kruize-operator:0.0.5 -b quay.io/kruize/kruize-operator-bundle:0.0.5"
+}
+
+# Parse command line arguments
+while getopts "o:b:h" opt; do
+    case $opt in
+        o)
+            OPERATOR_IMAGE="$OPTARG"
+            ;;
+        b)
+            BUNDLE_IMAGE="$OPTARG"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            log_error "Invalid option: -$OPTARG"
+            usage
+            exit 1
+            ;;
+        :)
+            log_error "Option -$OPTARG requires an argument"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$OPERATOR_IMAGE" ]] || [[ -z "$BUNDLE_IMAGE" ]]; then
+    log_error "Both operator image (-o) and bundle image (-b) are required"
+    echo ""
+    usage
+    exit 1
+fi
+
+# Extract version from image tags
+extract_version() {
+    local image=$1
+    echo ${image} | grep -oP ':\K[^:]+$'
+}
+
+OPERATOR_VERSION=$(extract_version "$OPERATOR_IMAGE")
+BUNDLE_VERSION=$(extract_version "$BUNDLE_IMAGE")
+
+if [[ "$OPERATOR_VERSION" != "$BUNDLE_VERSION" ]]; then
+    log_error "Version mismatch: operator version ($OPERATOR_VERSION) != bundle version ($BUNDLE_VERSION)"
+    exit 1
+fi
+
+VERSION=$OPERATOR_VERSION
+
+# Check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v ${CONTAINER_TOOL} &> /dev/null; then
+        log_error "${CONTAINER_TOOL} is not installed"
+        exit 1
+    fi
+    
+    if ! command -v make &> /dev/null; then
+        log_error "make is not installed"
+        exit 1
+    fi
+    
+    if ! command -v operator-sdk &> /dev/null && [[ ! -f "./bin/operator-sdk" ]]; then
+        log_info "Downloading operator-sdk..."
+        make operator-sdk
+    fi
+    
+    log_success "Prerequisites check passed"
+}
+
+# Update Makefile version
+update_makefile_version() {
+    log_info "Updating Makefile version to ${VERSION}..."
+    
+    if [[ -f "Makefile" ]]; then
+        sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+        log_success "Makefile version updated"
+    else
+        log_error "Makefile not found"
+        exit 1
+    fi
+}
+
+# Update CSV version
+update_csv_version() {
+    log_info "Updating CSV version to ${VERSION}..."
+    
+    # Update bundle CSV file
+    CSV_FILE="bundle/manifests/kruize-operator.clusterserviceversion.yaml"
+    if [[ -f "$CSV_FILE" ]]; then
+        sed -i "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$CSV_FILE"
+        sed -i "s/name: kruize-operator\.v.*/name: kruize-operator.v${VERSION}/" "$CSV_FILE"
+        log_success "Bundle CSV updated"
+    else
+        log_info "Bundle CSV not found (will be generated during bundle build)"
+    fi
+    
+    # Update base CSV file
+    BASE_CSV_FILE="config/manifests/bases/kruize-operator.clusterserviceversion.yaml"
+    if [[ -f "$BASE_CSV_FILE" ]]; then
+        sed -i "s|containerImage: .*|containerImage: ${OPERATOR_IMAGE}|" "$BASE_CSV_FILE"
+        log_success "Base CSV updated"
+    else
+        log_info "Base CSV not found"
+    fi
+}
+
+# Build and push operator image
+build_and_push_operator() {
+    log_info "Building and pushing operator image: ${OPERATOR_IMAGE}"
+    
+    log_info "Running: make docker-build docker-push IMG=${OPERATOR_IMAGE}"
+    make docker-build docker-push IMG=${OPERATOR_IMAGE}
+    
+    log_success "Operator image built and pushed: ${OPERATOR_IMAGE}"
+}
+
+# Verify operator image
+verify_operator_image() {
+    log_info "Verifying operator image..."
+    
+    if ${CONTAINER_TOOL} image inspect ${OPERATOR_IMAGE} &> /dev/null; then
+        log_success "Operator image verified"
+        ${CONTAINER_TOOL} image inspect ${OPERATOR_IMAGE} --format='  Size: {{.Size}} bytes'
+    else
+        log_error "Operator image not found"
+        return 1
+    fi
+}
+
+# Build and push bundle
+build_and_push_bundle() {
+    log_info "Building and pushing bundle image: ${BUNDLE_IMAGE}"
+    
+    log_info "Running: make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE}"
+    make bundle bundle-build bundle-push VERSION=${VERSION} IMG=${OPERATOR_IMAGE} BUNDLE_IMG=${BUNDLE_IMAGE}
+    
+    log_success "Bundle image built and pushed: ${BUNDLE_IMAGE}"
+}
+
+# Verify bundle
+verify_bundle() {
+    log_info "Verifying bundle with operator-sdk..."
+    
+    OPERATOR_SDK_BIN="operator-sdk"
+    if [[ -f "./bin/operator-sdk" ]]; then
+        OPERATOR_SDK_BIN="./bin/operator-sdk"
+    fi
+    
+    log_info "Validating bundle directory..."
+    ${OPERATOR_SDK_BIN} bundle validate ./bundle
+    
+    log_success "Bundle validation passed"
+    
+    if ${CONTAINER_TOOL} image inspect ${BUNDLE_IMAGE} &> /dev/null; then
+        log_success "Bundle image verified"
+        ${CONTAINER_TOOL} image inspect ${BUNDLE_IMAGE} --format='  Size: {{.Size}} bytes'
+    else
+        log_error "Bundle image not found"
+        return 1
+    fi
+}
+
+# Main execution
+main() {
+    echo ""
+    log_info "=========================================="
+    log_info "Kruize Operator Build & Push Script"
+    log_info "=========================================="
+    log_info "Version: ${VERSION}"
+    log_info "Operator Image: ${OPERATOR_IMAGE}"
+    log_info "Bundle Image: ${BUNDLE_IMAGE}"
+    log_info "Container Tool: ${CONTAINER_TOOL}"
+    log_info "=========================================="
+    echo ""
+    
+    check_prerequisites
+    
+    # Update versions
+    echo ""
+    log_info "=========================================="
+    log_info "Updating Version Files"
+    log_info "=========================================="
+    update_makefile_version
+    update_csv_version
+    
+    # Build and push operator
+    echo ""
+    log_info "=========================================="
+    log_info "Building and Pushing Operator Image"
+    log_info "=========================================="
+    build_and_push_operator
+    verify_operator_image
+    
+    # Build and push bundle
+    echo ""
+    log_info "=========================================="
+    log_info "Building and Pushing Bundle Image"
+    log_info "=========================================="
+    build_and_push_bundle
+    verify_bundle
+    
+    # Final summary
+    echo ""
+    log_info "=========================================="
+    log_success "Build and Push Complete!"
+    log_info "=========================================="
+    log_info "Version: ${VERSION}"
+    log_info "Operator Image: ${OPERATOR_IMAGE}"
+    log_info "Bundle Image: ${BUNDLE_IMAGE}"
+    echo ""
+    log_info "Next steps:"
+    log_info "  Deploy: make deploy IMG=${OPERATOR_IMAGE}"
+    log_info "  Test: operator-sdk run bundle ${BUNDLE_IMAGE}"
+    echo ""
+}
+
+# Run main function
+main
+


### PR DESCRIPTION
This PR adds a script to build and push operator and bundle images and also verify the bundle image using operator-sdk cmds.

## Summary by Sourcery

Add a script to automate building, pushing, and verifying Kruize operator and bundle images based on a shared version.

Enhancements:
- Introduce a helper script to coordinate operator and bundle image versioning, build, push, and verification using make and operator-sdk.

Build:
- Add an operator and bundle build-and-push shell script that supports docker/podman and updates version metadata in Makefile and CSV manifests before building images.