### PR TITLE
Remove storageclass for Kubernetes PV/PVC provisioning

### DIFF
--- a/internal/constants/resource_defaults.go
+++ b/internal/constants/resource_defaults.go
@@ -47,7 +47,8 @@ const (
 	// DefaultKubernetesPVStorageSize is the default PV storage size for Kubernetes/Minikube/Kind
 	DefaultKubernetesPVStorageSize = "1Gi"
 	// DefaultKubernetesStorageClassName is the default storage class for Kubernetes/Minikube/Kind
-	DefaultKubernetesStorageClassName = "manual"
+	// Empty string means no storage class will be used
+	DefaultKubernetesStorageClassName = ""
 	// DefaultKubernetesHostPath is the default host path for Kubernetes PV
-	DefaultKubernetesHostPath = "/tmp/data"
+	DefaultKubernetesHostPath = "/data/postgres"
 )

--- a/internal/constants/resource_defaults.go
+++ b/internal/constants/resource_defaults.go
@@ -47,7 +47,8 @@ const (
 	// DefaultKubernetesPVStorageSize is the default PV storage size for Kubernetes/Minikube/Kind
 	DefaultKubernetesPVStorageSize = "1Gi"
 	// DefaultKubernetesStorageClassName is the default storage class for Kubernetes/Minikube/Kind
-	// Empty string means no storage class will be used
+	// Empty string causes the storageClassName field to be omitted from PV/PVC specs,
+	// allowing Kubernetes to use the cluster's default StorageClass if one is configured.
 	DefaultKubernetesStorageClassName = ""
 	// DefaultKubernetesHostPath is the default host path for Kubernetes PV
 	DefaultKubernetesHostPath = "/data/postgres"

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -705,17 +706,37 @@ var _ = Describe("Kruize Controller", func() {
 
 				// Validate Kruize deployment has default resource configuration
 				kruizeContainer := getContainer(kruizeDeployment, "kruize")
-				Expect(kruizeContainer.Resources.Requests.Cpu().String()).To(Equal("700m"))
-				Expect(kruizeContainer.Resources.Requests.Memory().String()).To(Equal("768Mi"))
-				Expect(kruizeContainer.Resources.Limits.Cpu().String()).To(Equal("700m"))
-				Expect(kruizeContainer.Resources.Limits.Memory().String()).To(Equal("768Mi"))
+				expectedKruizeCPURequest := constants.DefaultKruizeCPURequest
+				expectedKruizeMemoryRequest := constants.DefaultKruizeMemoryRequest
+				expectedKruizeCPULimit := constants.DefaultKruizeCPULimit
+				expectedKruizeMemoryLimit := constants.DefaultKruizeMemoryLimit
+				expectedDBCPURequest := constants.DefaultDBCPURequest
+				expectedDBMemoryRequest := constants.DefaultDBMemoryRequest
+				expectedDBCPULimit := constants.DefaultDBCPULimit
+				expectedDBMemoryLimit := constants.DefaultDBMemoryLimit
+
+				if clusterType == constants.ClusterTypeMinikube || clusterType == constants.ClusterTypeKind {
+					expectedKruizeCPURequest = "0"
+					expectedKruizeMemoryRequest = "0"
+					expectedKruizeCPULimit = "0"
+					expectedKruizeMemoryLimit = "0"
+					expectedDBCPURequest = "0"
+					expectedDBMemoryRequest = "0"
+					expectedDBCPULimit = "0"
+					expectedDBMemoryLimit = "0"
+				}
+
+				Expect(kruizeContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedKruizeCPURequest))).To(Equal(0))
+				Expect(kruizeContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedKruizeMemoryRequest))).To(Equal(0))
+				Expect(kruizeContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedKruizeCPULimit))).To(Equal(0))
+				Expect(kruizeContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedKruizeMemoryLimit))).To(Equal(0))
 
 				// Validate DB deployment has default resource configuration
 				dbContainer := getContainer(kruizeDBDeployment, "kruize-db")
-				Expect(dbContainer.Resources.Requests.Cpu().String()).To(Equal("500m"))
-				Expect(dbContainer.Resources.Requests.Memory().String()).To(Equal("100Mi"))
-				Expect(dbContainer.Resources.Limits.Cpu().String()).To(Equal("500m"))
-				Expect(dbContainer.Resources.Limits.Memory().String()).To(Equal("100Mi"))
+				Expect(dbContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedDBCPURequest))).To(Equal(0))
+				Expect(dbContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedDBMemoryRequest))).To(Equal(0))
+				Expect(dbContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedDBCPULimit))).To(Equal(0))
+				Expect(dbContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedDBMemoryLimit))).To(Equal(0))
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
 				return g.NamespacedResources()
@@ -776,7 +797,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-ui deployment specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift)
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 			
@@ -922,10 +943,10 @@ var _ = Describe("Kruize Controller", func() {
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
 			container := getContainer(kruizeDeployment, "kruize")
 			
-			// Verify default values for unset fields
-			Expect(container.Resources.Requests.Cpu().String()).To(Equal("700m"))
-			Expect(container.Resources.Requests.Memory().String()).To(Equal("768Mi"))
-			Expect(container.Resources.Limits.Cpu().String()).To(Equal("700m"))
+			// Verify minikube leaves unset fields empty while preserving explicit values
+			Expect(container.Resources.Requests.Cpu().String()).To(Equal("0"))
+			Expect(container.Resources.Requests.Memory().String()).To(Equal("0"))
+			Expect(container.Resources.Limits.Cpu().String()).To(Equal("0"))
 			// Verify custom memory limit
 			Expect(container.Resources.Limits.Memory().String()).To(Equal("2Gi"))
 		})
@@ -942,14 +963,14 @@ var _ = Describe("Kruize Controller", func() {
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
 			container := getContainer(kruizeDBDeployment, "kruize-db")
 			
-			// Verify default CPU request
-			Expect(container.Resources.Requests.Cpu().String()).To(Equal("500m"))
+			// Verify minikube leaves unspecified CPU request empty
+			Expect(container.Resources.Requests.Cpu().String()).To(Equal("0"))
 			// Verify custom memory request
 			Expect(container.Resources.Requests.Memory().String()).To(Equal("256Mi"))
 			// Verify custom CPU limit
 			Expect(container.Resources.Limits.Cpu().String()).To(Equal("1"))
-			// Verify default memory limit
-			Expect(container.Resources.Limits.Memory().String()).To(Equal("100Mi"))
+			// Verify minikube leaves unspecified memory limit empty
+			Expect(container.Resources.Limits.Memory().String()).To(Equal("0"))
 		})
 	})
 
@@ -972,7 +993,7 @@ var _ = Describe("Kruize Controller", func() {
 			Expect(pv.Spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}))
 
 			// Find the PVC
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.NamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("1Gi"))
 			Expect(*pvc.Spec.StorageClassName).To(Equal("custom-storage"))
@@ -997,7 +1018,7 @@ var _ = Describe("Kruize Controller", func() {
 			Expect(pv.Spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}))
 
 			// Find the PVC
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.KubernetesNamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("2Gi"))
 			Expect(*pvc.Spec.StorageClassName).To(Equal("k8s-storage"))
@@ -1019,7 +1040,7 @@ var _ = Describe("Kruize Controller", func() {
 			Expect(pv.Spec.Capacity.Storage().String()).To(Equal("5Gi"))
 
 			// Find the PVC and verify it uses PVStorageSize
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.NamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			// PVC should use PVStorageSize since PVCStorageSize was not specified
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("5Gi"))
@@ -1040,7 +1061,7 @@ var _ = Describe("Kruize Controller", func() {
 			Expect(pv.Spec.Capacity.Storage().String()).To(Equal("4Gi"))
 
 			// Find the PVC and verify it uses PVStorageSize
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.KubernetesNamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			// PVC should use PVStorageSize since PVCStorageSize was not specified
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("4Gi"))
@@ -1060,7 +1081,7 @@ var _ = Describe("Kruize Controller", func() {
 			Expect(pv.Spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}))
 
 			// Find the PVC
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.NamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("500Mi"))
 			Expect(*pvc.Spec.StorageClassName).To(Equal("manual"))
@@ -1076,15 +1097,15 @@ var _ = Describe("Kruize Controller", func() {
 			pv := findPersistentVolume(clusterResources)
 			Expect(pv).NotTo(BeNil(), "PersistentVolume should exist")
 			Expect(pv.Spec.Capacity.Storage().String()).To(Equal("1Gi"))
-			Expect(pv.Spec.StorageClassName).To(Equal("manual"))
-			Expect(pv.Spec.PersistentVolumeSource.HostPath.Path).To(Equal("/tmp/data"))
+			Expect(pv.Spec.StorageClassName).To(Equal(""))
+			Expect(pv.Spec.PersistentVolumeSource.HostPath.Path).To(Equal("/data/postgres"))
 			Expect(pv.Spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}))
 
 			// Find the PVC
-			pvc := findPersistentVolumeClaim(clusterResources)
+			pvc := findPersistentVolumeClaim(generator.KubernetesNamespacedResources())
 			Expect(pvc).NotTo(BeNil(), "PersistentVolumeClaim should exist")
 			Expect(pvc.Spec.Resources.Requests.Storage().String()).To(Equal("1Gi"))
-			Expect(*pvc.Spec.StorageClassName).To(Equal("manual"))
+			Expect(pvc.Spec.StorageClassName).To(BeNil())
 			Expect(pvc.Spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}))
 		})
 	})

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -716,27 +716,30 @@ var _ = Describe("Kruize Controller", func() {
 				expectedDBMemoryLimit := constants.DefaultDBMemoryLimit
 
 				if clusterType == constants.ClusterTypeMinikube || clusterType == constants.ClusterTypeKind {
-					expectedKruizeCPURequest = "0"
-					expectedKruizeMemoryRequest = "0"
-					expectedKruizeCPULimit = "0"
-					expectedKruizeMemoryLimit = "0"
-					expectedDBCPURequest = "0"
-					expectedDBMemoryRequest = "0"
-					expectedDBCPULimit = "0"
-					expectedDBMemoryLimit = "0"
+					// For minikube/kind, resources should be empty if not specified in the CR
+					// This allows flexible resource allocation in local development environments
+					Expect(kruizeContainer.Resources.Requests).To(Or(BeNil(), BeEmpty()))
+					Expect(kruizeContainer.Resources.Limits).To(Or(BeNil(), BeEmpty()))
+					
+					// Validate DB deployment has empty resource configuration
+					dbContainer := getContainer(kruizeDBDeployment, "kruize-db")
+					Expect(dbContainer.Resources.Requests).To(Or(BeNil(), BeEmpty()))
+					Expect(dbContainer.Resources.Limits).To(Or(BeNil(), BeEmpty()))
+				} else {
+					// For OpenShift, validate default resource configuration
+					// Note: .Cmp() returns 0 when quantities are equal, -1 when less, 1 when greater
+					Expect(kruizeContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedKruizeCPURequest))).To(Equal(0))
+					Expect(kruizeContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedKruizeMemoryRequest))).To(Equal(0))
+					Expect(kruizeContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedKruizeCPULimit))).To(Equal(0))
+					Expect(kruizeContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedKruizeMemoryLimit))).To(Equal(0))
+
+					// Validate DB deployment has default resource configuration
+					dbContainer := getContainer(kruizeDBDeployment, "kruize-db")
+					Expect(dbContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedDBCPURequest))).To(Equal(0))
+					Expect(dbContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedDBMemoryRequest))).To(Equal(0))
+					Expect(dbContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedDBCPULimit))).To(Equal(0))
+					Expect(dbContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedDBMemoryLimit))).To(Equal(0))
 				}
-
-				Expect(kruizeContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedKruizeCPURequest))).To(Equal(0))
-				Expect(kruizeContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedKruizeMemoryRequest))).To(Equal(0))
-				Expect(kruizeContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedKruizeCPULimit))).To(Equal(0))
-				Expect(kruizeContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedKruizeMemoryLimit))).To(Equal(0))
-
-				// Validate DB deployment has default resource configuration
-				dbContainer := getContainer(kruizeDBDeployment, "kruize-db")
-				Expect(dbContainer.Resources.Requests.Cpu().Cmp(resource.MustParse(expectedDBCPURequest))).To(Equal(0))
-				Expect(dbContainer.Resources.Requests.Memory().Cmp(resource.MustParse(expectedDBMemoryRequest))).To(Equal(0))
-				Expect(dbContainer.Resources.Limits.Cpu().Cmp(resource.MustParse(expectedDBCPULimit))).To(Equal(0))
-				Expect(dbContainer.Resources.Limits.Memory().Cmp(resource.MustParse(expectedDBMemoryLimit))).To(Equal(0))
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
 				return g.NamespacedResources()

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -1345,6 +1345,24 @@ func (g *KruizeResourceGenerator) kruizeDBPersistentVolumeKubernetes() *corev1.P
 	pvName := g.getPVName("kruize-db-pv")
 	labels := g.getPVLabels(map[string]string{"app": "kruize-db"})
 
+	pvSpec := corev1.PersistentVolumeSpec{
+		Capacity: corev1.ResourceList{
+			corev1.ResourceStorage: g.parseResourceQuantity(pvStorageSize, constants.DefaultKubernetesPVStorageSize),
+		},
+		AccessModes:                   accessModes,
+		PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+		PersistentVolumeSource: corev1.PersistentVolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: hostPath,
+			},
+		},
+	}
+
+	// Only set StorageClassName if it's not empty
+	if storageClassName != "" {
+		pvSpec.StorageClassName = storageClassName
+	}
+
 	return &corev1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -1354,19 +1372,7 @@ func (g *KruizeResourceGenerator) kruizeDBPersistentVolumeKubernetes() *corev1.P
 			Name:   pvName,
 			Labels: labels,
 		},
-		Spec: corev1.PersistentVolumeSpec{
-			StorageClassName: storageClassName,
-			Capacity: corev1.ResourceList{
-				corev1.ResourceStorage: g.parseResourceQuantity(pvStorageSize, constants.DefaultKubernetesPVStorageSize),
-			},
-			AccessModes:                   accessModes,
-			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: hostPath,
-				},
-			},
-		},
+		Spec: pvSpec,
 	}
 }
 
@@ -1375,6 +1381,20 @@ func (g *KruizeResourceGenerator) kruizeDBPersistentVolumeClaimKubernetes() *cor
 	_, pvcStorageSize, storageClassName, _, accessModes := g.getPVConfigKubernetes()
 	pvcName := g.getPVCName("kruize-db-pvc")
 	labels := g.getPVCLabels(map[string]string{"app": "kruize-db"})
+
+	pvcSpec := corev1.PersistentVolumeClaimSpec{
+		AccessModes: accessModes,
+		Resources: corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: g.parseResourceQuantity(pvcStorageSize, constants.DefaultKubernetesPVStorageSize),
+			},
+		},
+	}
+
+	// Only set StorageClassName if it's not empty
+	if storageClassName != "" {
+		pvcSpec.StorageClassName = &storageClassName
+	}
 
 	return &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
@@ -1386,15 +1406,7 @@ func (g *KruizeResourceGenerator) kruizeDBPersistentVolumeClaimKubernetes() *cor
 			Namespace: g.Namespace,
 			Labels:    labels,
 		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: &storageClassName,
-			AccessModes:      accessModes,
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: g.parseResourceQuantity(pvcStorageSize, constants.DefaultKubernetesPVStorageSize),
-				},
-			},
-		},
+		Spec: pvcSpec,
 	}
 }
 


### PR DESCRIPTION
This PR simplifies PV/PVC configuration for Kubernetes/Minikube/Kind environments by removing the StorageClass dependency, enabling pure static provisioning with direct PV-to-PVC binding.

Similar to minikube manifest: [kruize-crc-minikube.yaml](https://github.com/kruize/autotune/blob/master/manifests/crc/default-db-included-installation/minikube/kruize-crc-minikube.yaml#L108)

## Summary by Sourcery

Simplify Kubernetes database volume configuration by making StorageClass usage optional for PV/PVC generation and updating default storage settings.

Enhancements:
- Allow generated PersistentVolumes and PersistentVolumeClaims to omit StorageClass when none is configured, enabling static PV-to-PVC binding across Kubernetes/Minikube/Kind environments.
- Adjust default Kubernetes storage configuration to remove the manual StorageClass and use a more appropriate default host path for the database volume.