### PR TITLE
[WIP] Adding Support For Configurable Optimizer Config

### DIFF
--- a/api/v1alpha1/kruize_types.go
+++ b/api/v1alpha1/kruize_types.go
@@ -40,6 +40,10 @@ type KruizeSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autotune UI Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Autotune_ui_image string `json:"autotune_ui_image"`
 
+	// Container image for Kruize Optimizer
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Optimizer Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Optimizer_image   string `json:"optimizer_image,omitempty"`
+
 	// Target namespace for Kruize deployment
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace         string `json:"namespace"`

--- a/api/v1alpha1/kruize_types.go
+++ b/api/v1alpha1/kruize_types.go
@@ -63,6 +63,10 @@ type KruizeSpec struct {
 	// Kruize application resource configuration
 	// +optional
 	Kruize *KruizeAppConfig `json:"kruize,omitempty"`
+
+	// Kruize Optimizer configuration
+	// +optional
+	Optimizer *OptimizerConfig `json:"optimizer,omitempty"`
 }
 
 // KubernetesResourceRequirements defines Kubernetes-style resource requirements
@@ -92,6 +96,57 @@ type KruizeAppConfig struct {
 	// Resource requirements
 	// +optional
 	Resources *KubernetesResourceRequirements `json:"resources,omitempty"`
+}
+
+// OptimizerConfig defines configuration for Kruize Optimizer
+type OptimizerConfig struct {
+	// Resource requirements
+	// +optional
+	Resources *KubernetesResourceRequirements `json:"resources,omitempty"`
+
+	// Kruize URL for optimizer to connect to
+	// +optional
+	KruizeURL string `json:"kruizeURL,omitempty"`
+
+	// State refresh interval (e.g., "60m", "1h")
+	// +optional
+	StateRefreshInterval string `json:"stateRefreshInterval,omitempty"`
+
+	// Bulk scheduler interval (e.g., "15m")
+	// +optional
+	BulkSchedulerInterval string `json:"bulkSchedulerInterval,omitempty"`
+
+	// Bulk scheduler startup delay (e.g., "1m")
+	// +optional
+	BulkSchedulerStartupDelay string `json:"bulkSchedulerStartupDelay,omitempty"`
+
+	// Bulk measurement duration (e.g., "15min")
+	// +optional
+	BulkMeasurementDuration string `json:"bulkMeasurementDuration,omitempty"`
+
+	// Webhook URL for Kruize optimizer
+	// +optional
+	WebhookURL string `json:"webhookURL,omitempty"`
+
+	// Target label limit
+	// +optional
+	TargetLabelLimit string `json:"targetLabelLimit,omitempty"`
+
+	// Target labels in JSON format
+	// +optional
+	TargetLabels string `json:"targetLabels,omitempty"`
+
+	// Default datasource name
+	// +optional
+	DefaultDatasource string `json:"defaultDatasource,omitempty"`
+
+	// Default metadata profile name
+	// +optional
+	DefaultMetadataProfile string `json:"defaultMetadataProfile,omitempty"`
+
+	// Default metric profile name
+	// +optional
+	DefaultMetricProfile string `json:"defaultMetricProfile,omitempty"`
 }
 
 // KruizeDBConfig defines configuration for Kruize database

--- a/config/crd/bases/kruize.io_kruizes.yaml
+++ b/config/crd/bases/kruize.io_kruizes.yaml
@@ -151,6 +151,9 @@ spec:
               namespace:
                 description: Target namespace for Kruize deployment
                 type: string
+              optimizer_image:
+                description: Container image for Kruize Optimizer
+                type: string
               persistentVolume:
                 description: Persistent Volume configuration
                 properties:

--- a/config/crd/bases/kruize.io_kruizes.yaml
+++ b/config/crd/bases/kruize.io_kruizes.yaml
@@ -151,6 +151,67 @@ spec:
               namespace:
                 description: Target namespace for Kruize deployment
                 type: string
+              optimizer:
+                description: Kruize Optimizer configuration
+                properties:
+                  bulkMeasurementDuration:
+                    description: Bulk measurement duration (e.g., "15min")
+                    type: string
+                  bulkSchedulerInterval:
+                    description: Bulk scheduler interval (e.g., "15m")
+                    type: string
+                  bulkSchedulerStartupDelay:
+                    description: Bulk scheduler startup delay (e.g., "1m")
+                    type: string
+                  defaultDatasource:
+                    description: Default datasource name
+                    type: string
+                  defaultMetadataProfile:
+                    description: Default metadata profile name
+                    type: string
+                  defaultMetricProfile:
+                    description: Default metric profile name
+                    type: string
+                  kruizeURL:
+                    description: Kruize URL for optimizer to connect to
+                    type: string
+                  resources:
+                    description: Resource requirements
+                    properties:
+                      limits:
+                        description: Resource limits
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Resource requests
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                    type: object
+                  stateRefreshInterval:
+                    description: State refresh interval (e.g., "60m", "1h")
+                    type: string
+                  targetLabelLimit:
+                    description: Target label limit
+                    type: string
+                  targetLabels:
+                    description: Target labels in JSON format
+                    type: string
+                  webhookURL:
+                    description: Webhook URL for Kruize optimizer
+                    type: string
+                type: object
               optimizer_image:
                 description: Container image for Kruize Optimizer
                 type: string

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -10,7 +10,7 @@ spec:
   cluster_type: "openshift"
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
-  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1_mvp"
+  optimizer_image: "quay.io/kruize/kruize-optimizer:0.0.1"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -72,3 +72,18 @@ spec:
       limits:
         memory: "768Mi"
         cpu: "0.7"
+  
+  # Kruize Optimizer configuration (optional)
+  optimizer:
+    kruizeURL: "http://kruize:8080"
+    stateRefreshInterval: "60m"
+    bulkSchedulerInterval: "15m"
+    bulkSchedulerStartupDelay: "1m"
+    bulkMeasurementDuration: "15min"
+    webhookURL: "http://kruize-optimizer:8080/webhook"
+    targetLabelLimit: "1"
+    targetLabels: '{"kruize/autotune": "enabled"}'
+    defaultDatasource: "prometheus-1"
+    defaultMetadataProfile: "cluster-metadata-local-monitoring"
+    defaultMetricProfile: "resource-optimization-local-monitoring"
+

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,14 +8,9 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
-<<<<<<< HEAD
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
-=======
-  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
-  autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
-  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1-test"
->>>>>>> 440171c (adding optimizer integration)
+  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1_mvp"
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/config/samples/v1alpha1_kruize.yaml
+++ b/config/samples/v1alpha1_kruize.yaml
@@ -8,8 +8,14 @@ metadata:
 spec:
   # Supported values: "openshift", "minikube", "kind"
   cluster_type: "openshift"
+<<<<<<< HEAD
   autotune_image: "quay.io/kruize/autotune_operator:0.9"
   autotune_ui_image: "quay.io/kruize/kruize-ui:0.1.0"
+=======
+  autotune_image: "quay.io/kruize/autotune_operator:0.8.1"
+  autotune_ui_image: "quay.io/kruize/kruize-ui:0.0.9"
+  optimizer_image: "quay.io/rh-ee-shesaxen/optimizer:0.1-test"
+>>>>>>> 440171c (adding optimizer integration)
   # For OpenShift, use: "openshift-tuning", Minikube/KIND, use: "monitoring"
   namespace: "openshift-tuning"
   

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -39,7 +39,7 @@ const (
 	defaultUIImageTag = "0.1.0"
 	
 	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
-	defaultOptimizerImageTag = "0.1_mvp"
+	defaultOptimizerImageTag = "0.0.1"
 	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -48,7 +48,7 @@ const (
 	defaultUIImageRepo = "quay.io/kruize/kruize-ui"
 	
 	// defaultOptimizerImageRepo is the default repository for Kruize Optimizer image
-	defaultOptimizerImageRepo = "quay.io/rh-ee-shesaxen/optimizer"
+	defaultOptimizerImageRepo = "quay.io/kruize/kruize-optimizer"
 )
 
 // Package-level variables that cache the resolved default images.

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -39,7 +39,7 @@ const (
 	defaultUIImageTag = "0.1.0"
 	
 	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
-	defaultOptimizerImageTag = "0.1-test"
+	defaultOptimizerImageTag = "0.1_mvp"
 	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"

--- a/internal/constants/kruize_images.go
+++ b/internal/constants/kruize_images.go
@@ -25,6 +25,9 @@ const (
 	
 	// envUIImage is the environment variable name for overriding the default Kruize UI image
 	envUIImage = "DEFAULT_AUTOTUNE_UI_IMAGE"
+	
+	// envOptimizerImage is the environment variable name for overriding the default Optimizer image
+	envOptimizerImage = "DEFAULT_OPTIMIZER_IMAGE"
 )
 
 // Default container image versions
@@ -35,11 +38,17 @@ const (
 	// defaultUIImageTag is the default tag for Kruize UI image
 	defaultUIImageTag = "0.1.0"
 	
+	// defaultOptimizerImageTag is the default tag for Kruize Optimizer image
+	defaultOptimizerImageTag = "0.1-test"
+	
 	// defaultAutotuneImageRepo is the default repository for Kruize Autotune image
 	defaultAutotuneImageRepo = "quay.io/kruize/autotune_operator"
 	
 	// defaultUIImageRepo is the default repository for Kruize UI image
 	defaultUIImageRepo = "quay.io/kruize/kruize-ui"
+	
+	// defaultOptimizerImageRepo is the default repository for Kruize Optimizer image
+	defaultOptimizerImageRepo = "quay.io/rh-ee-shesaxen/optimizer"
 )
 
 // Package-level variables that cache the resolved default images.
@@ -47,7 +56,8 @@ const (
 // environment variable lookups on every function call.
 var (
 	defaultAutotuneImage   string
-	defaultUIImage string
+	defaultUIImage         string
+	defaultOptimizerImage  string
 )
 
 // init resolves the default images by checking environment variables once at package initialization.
@@ -66,6 +76,13 @@ func init() {
 	} else {
 		defaultUIImage = defaultUIImageRepo + ":" + defaultUIImageTag
 	}
+	
+	// Resolve Optimizer image
+	if envImage := os.Getenv(envOptimizerImage); envImage != "" {
+		defaultOptimizerImage = envImage
+	} else {
+		defaultOptimizerImage = defaultOptimizerImageRepo + ":" + defaultOptimizerImageTag
+	}
 }
 
 // GetDefaultAutotuneImage returns the cached default Autotune image.
@@ -78,4 +95,10 @@ func GetDefaultAutotuneImage() string {
 // The image is resolved once at package initialization from environment variables or defaults.
 func GetDefaultUIImage() string {
 	return defaultUIImage
+}
+
+// GetDefaultOptimizerImage returns the cached default Optimizer image.
+// The image is resolved once at package initialization from environment variables or defaults.
+func GetDefaultOptimizerImage() string {
+	return defaultOptimizerImage
 }

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -194,6 +194,53 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 	}
 }
 
+// waitForKruizeDeploymentReady waits specifically for the Kruize deployment to be ready
+// before proceeding with optimizer deployment
+func (r *KruizeReconciler) waitForKruizeDeploymentReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	logger := log.FromContext(ctx)
+
+	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
+
+	timeoutCh := time.After(timeout)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCh:
+			return fmt.Errorf("timeout waiting for Kruize deployment to be ready in namespace %s", namespace)
+
+		case <-ticker.C:
+			// Check if kruize deployment exists and is ready
+			deployment := &appsv1.Deployment{}
+			err := r.Get(ctx, client.ObjectKey{
+				Namespace: namespace,
+				Name:      "kruize",
+			}, deployment)
+
+			if err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("Kruize deployment not found yet, waiting...", "namespace", namespace)
+					continue
+				}
+				logger.Error(err, "Failed to get Kruize deployment")
+				continue
+			}
+
+			// Check if deployment is ready
+			if deployment.Status.ReadyReplicas > 0 && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
+				logger.Info("Kruize deployment is ready", "namespace", namespace, "readyReplicas", deployment.Status.ReadyReplicas)
+				return nil
+			}
+
+			logger.Info("Waiting for Kruize deployment to be ready",
+				"namespace", namespace,
+				"readyReplicas", deployment.Status.ReadyReplicas,
+				"desiredReplicas", deployment.Status.Replicas)
+		}
+	}
+}
+
 func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace string) (int, int, map[string]string, error) {
 	podList := &corev1.PodList{}
 	err := r.Client.List(ctx, podList, client.InNamespace(namespace))
@@ -327,15 +374,43 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		return err
 	}
 
-	// Reconcile namespace-scoped resources (WITH owner reference)
-	for _, obj := range namespacedObjects {
+	// Deploy core Kruize resources (DB, Kruize, UI) without optimizer
+	var coreResources []client.Object
+	var optimizerResources []client.Object
+
+	if clusterType == constants.ClusterTypeOpenShift {
+		coreResources = k8sObjectGenerator.CoreNamespacedResources()
+		optimizerResources = k8sObjectGenerator.OptimizerNamespacedResources()
+	} else {
+		coreResources = k8sObjectGenerator.CoreKubernetesNamespacedResources()
+		optimizerResources = k8sObjectGenerator.OptimizerKubernetesNamespacedResources()
+	}
+
+	logger.Info("Deploying core Kruize resources", "namespace", namespace)
+	for _, obj := range coreResources {
 		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
-			logger.Error(err, "Failed to reconcile namespaced resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
+			logger.Error(err, "Failed to reconcile core resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
 			return err
 		}
 	}
 
-	logger.Info("Successfully reconciled all dependent resources", "clusterType", clusterType)
+	// Wait for Kruize deployment to be ready
+	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
+	if err := r.waitForKruizeDeploymentReady(ctx, namespace, 3*time.Minute); err != nil {
+		logger.Error(err, "Kruize deployment not ready, will retry")
+		return err
+	}
+
+	// Deploy optimizer resources after Kruize is ready
+	logger.Info("Kruize is ready, now deploying optimizer", "namespace", namespace)
+	for _, obj := range optimizerResources {
+		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
+			logger.Error(err, "Failed to reconcile optimizer resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())
+			return err
+		}
+	}
+
+	logger.Info("Successfully reconciled all dependent resources in phases", "clusterType", clusterType)
 	return nil
 }
 

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -161,7 +161,7 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 		return nil
 	}
 
-	requiredPods := []string{"kruize", "kruize-ui-nginx", "kruize-db"}
+	requiredPods := []string{"kruize", "kruize-ui-nginx", "kruize-db", "kruize-optimizer"}
 	logger.Info("Waiting for Kruize pods to be ready", "namespace", namespace, "pods", requiredPods)
 
 	timeoutCh := time.After(timeout)
@@ -183,8 +183,8 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 			logger.Info("Pod status check", "ready", readyPods, "total", totalPods, "namespace", namespace)
 			fmt.Printf("Pod status: %v\n", podStatus)
 
-			// Check if we have all required pods running
-			if readyPods >= 3 && totalPods >= 3 {
+			// Check if we have all required pods running (kruize, kruize-ui-nginx, kruize-db, kruize-optimizer)
+			if readyPods >= 4 && totalPods >= 4 {
 				logger.Info("All Kruize pods are ready", "readyPods", readyPods)
 				return nil
 			}
@@ -244,7 +244,8 @@ func (r *KruizeReconciler) deployKruize(ctx context.Context, kruize *kruizev1alp
 		"cluster_type", kruize.Spec.Cluster_type,
 		"namespace", kruize.Spec.Namespace,
 		"autotune_image", kruize.Spec.Autotune_image,
-		"autotune_ui_image", kruize.Spec.Autotune_ui_image)
+		"autotune_ui_image", kruize.Spec.Autotune_ui_image,
+		"optimizer_image", kruize.Spec.Optimizer_image)
 
 	// Normalize and validate cluster type (case-insensitive)
 	cluster_type := kruize.Spec.Cluster_type
@@ -282,6 +283,7 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		namespace,
 		kruize.Spec.Autotune_image,
 		kruize.Spec.Autotune_ui_image,
+		kruize.Spec.Optimizer_image,
 		clusterType,
 		&kruize.Spec,
 		ctx,

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -195,52 +195,6 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 	}
 }
 
-// waitForKruizeDeploymentReady waits specifically for the Kruize deployment to be ready
-// before proceeding with optimizer deployment
-func (r *KruizeReconciler) waitForKruizeDeploymentReady(ctx context.Context, namespace string, timeout time.Duration) error {
-	logger := log.FromContext(ctx)
-
-	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
-
-	timeoutCh := time.After(timeout)
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-timeoutCh:
-			return fmt.Errorf("timeout waiting for Kruize deployment to be ready in namespace %s", namespace)
-
-		case <-ticker.C:
-			// Check if kruize deployment exists and is ready
-			deployment := &appsv1.Deployment{}
-			err := r.Get(ctx, client.ObjectKey{
-				Namespace: namespace,
-				Name:      "kruize",
-			}, deployment)
-
-			if err != nil {
-				if errors.IsNotFound(err) {
-					logger.Info("Kruize deployment not found yet, waiting...", "namespace", namespace)
-					continue
-				}
-				logger.Error(err, "Failed to get Kruize deployment")
-				continue
-			}
-
-			// Check if deployment is ready
-			if deployment.Status.ReadyReplicas > 0 && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-				logger.Info("Kruize deployment is ready", "namespace", namespace, "readyReplicas", deployment.Status.ReadyReplicas)
-				return nil
-			}
-
-			logger.Info("Waiting for Kruize deployment to be ready",
-				"namespace", namespace,
-				"readyReplicas", deployment.Status.ReadyReplicas,
-				"desiredReplicas", deployment.Status.Replicas)
-		}
-	}
-}
 
 func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace string) (int, int, map[string]string, error) {
 	podList := &corev1.PodList{}
@@ -392,15 +346,9 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 		}
 	}
 
-	// Wait for Kruize deployment to be ready
-	logger.Info("Waiting for Kruize deployment to be ready before deploying optimizer", "namespace", namespace)
-	if err := r.waitForKruizeDeploymentReady(ctx, namespace, 3*time.Minute); err != nil {
-		logger.Error(err, "Kruize deployment not ready, will retry")
-		return err
-	}
-
-	// Deploy optimizer resources after Kruize is ready
-	logger.Info("Kruize is ready, now deploying optimizer", "namespace", namespace)
+	// Deploy optimizer resources with init container that waits for Kruize
+	// The init container in the optimizer deployment will handle waiting for Kruize to be ready
+	logger.Info("Deploying optimizer resources (init container will wait for Kruize to be ready)", "namespace", namespace)
 	for _, obj := range optimizerResources {
 		if err := r.reconcileNamespacedResource(ctx, kruize, obj); err != nil {
 			logger.Error(err, "Failed to reconcile optimizer resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name", obj.GetName())

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -339,25 +340,22 @@ func (r *KruizeReconciler) deployKruizeComponents(ctx context.Context, namespace
 
 	// Reconcile cluster-scoped resources based on cluster type
 	var clusterScopedObjects []client.Object
-	var namespacedObjects []client.Object
 	var configmap client.Object
 
 	if clusterType == constants.ClusterTypeOpenShift {
 		// OpenShift-specific resources
-        	kruizeServiceAccount := k8sObjectGenerator.KruizeServiceAccount()
-        	if err := r.reconcileClusterResource(ctx, kruizeServiceAccount); err != nil {
-            		logger.Error(err, "Failed to reconcile kruize service account")
-            		return err
-        	}
+	       	kruizeServiceAccount := k8sObjectGenerator.KruizeServiceAccount()
+	       	if err := r.reconcileClusterResource(ctx, kruizeServiceAccount); err != nil {
+	           		logger.Error(err, "Failed to reconcile kruize service account")
+	           		return err
+	       	}
 
 		clusterScopedObjects = k8sObjectGenerator.ClusterScopedResources()
 		configmap = k8sObjectGenerator.KruizeConfigMap()
-		namespacedObjects = k8sObjectGenerator.NamespacedResources()
 	} else {
 		// Kind/Minikube-specific resources
 		clusterScopedObjects = k8sObjectGenerator.KubernetesClusterScopedResources()
 		configmap = k8sObjectGenerator.KruizeConfigMapKubernetes()
-		namespacedObjects = k8sObjectGenerator.KubernetesNamespacedResources()
 	}
 
 	// Reconcile cluster-scoped resources (no owner reference)

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -467,7 +467,9 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should generate namespaced resources for OpenShift", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
@@ -481,7 +483,9 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should generate Kubernetes namespaced resources", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
@@ -522,7 +526,9 @@ var _ = Describe("Kruize Controller", func() {
 
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			Expect(namespacedResources).NotTo(BeEmpty())
 
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -551,7 +557,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should allow partial resource overrides while preserving defaults", func() {
 			// First, generate resources with default configuration to capture default resources
 			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			defaultNamespacedResources := defaultGenerator.NamespacedResources()
+			defaultCoreResources := defaultGenerator.CoreNamespacedResources()
+			defaultOptimizerResources := defaultGenerator.OptimizerNamespacedResources()
+			defaultNamespacedResources := append(defaultCoreResources, defaultOptimizerResources...)
 
 			defaultKruizeDeployment := findDeployment(defaultNamespacedResources, "kruize")
 			defaultDBDeployment := findDeployment(defaultNamespacedResources, "kruize-db-deployment")
@@ -570,7 +578,9 @@ var _ = Describe("Kruize Controller", func() {
 				Kruize:   createKruizeAppConfig("300m", "", "", ""),
 			}
 			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
-			partialNamespacedResources := partialGenerator.NamespacedResources()
+			partialCoreResources := partialGenerator.CoreNamespacedResources()
+			partialOptimizerResources := partialGenerator.OptimizerNamespacedResources()
+			partialNamespacedResources := append(partialCoreResources, partialOptimizerResources...)
 
 			partialKruizeDeployment := findDeployment(partialNamespacedResources, "kruize")
 			partialDBDeployment := findDeployment(partialNamespacedResources, "kruize-db-deployment")
@@ -716,10 +726,14 @@ var _ = Describe("Kruize Controller", func() {
 				Expect(dbContainer.Resources.Limits.Memory().String()).To(Equal("100Mi"))
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.NamespacedResources()
+				coreResources := g.CoreNamespacedResources()
+				optimizerResources := g.OptimizerNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 			Entry("for Kubernetes", constants.ClusterTypeMinikube, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.KubernetesNamespacedResources()
+				coreResources := g.CoreKubernetesNamespacedResources()
+				optimizerResources := g.OptimizerKubernetesNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 		)
 
@@ -754,10 +768,14 @@ var _ = Describe("Kruize Controller", func() {
 				Expect(dbContainer.Resources.Limits.Memory().String()).To(Equal("1Gi"))
 			},
 			Entry("for OpenShift", constants.ClusterTypeOpenShift, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.NamespacedResources()
+				coreResources := g.CoreNamespacedResources()
+				optimizerResources := g.OptimizerNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 			Entry("for Kubernetes", constants.ClusterTypeMinikube, func(g *utils.KruizeResourceGenerator) []client.Object {
-				return g.KubernetesNamespacedResources()
+				coreResources := g.CoreKubernetesNamespacedResources()
+				optimizerResources := g.OptimizerKubernetesNamespacedResources()
+				return append(coreResources, optimizerResources...)
 			}),
 		)
 	})
@@ -766,7 +784,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize pod specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -776,7 +796,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize-ui deployment specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 			
 			// Find the Kruize UI deployment
 			var kruizeUIDeployment *appsv1.Deployment
@@ -796,7 +818,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize-db pod specification", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -809,7 +833,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -830,7 +856,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -848,7 +876,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should use default resources when ResourceConfig is nil", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "",constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -869,7 +899,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -894,7 +926,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -914,7 +948,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize deployment
 			kruizeDeployment := findDeployment(namespacedResources, "kruize")
@@ -934,7 +970,9 @@ var _ = Describe("Kruize Controller", func() {
 			}
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
-			namespacedResources := generator.KubernetesNamespacedResources()
+			coreResources := generator.CoreKubernetesNamespacedResources()
+			optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB deployment
 			kruizeDBDeployment := findDeployment(namespacedResources, "kruize-db-deployment")
@@ -1090,7 +1128,9 @@ var _ = Describe("Kruize Controller", func() {
 	Context("Route and service creation", func() {
 		It("should generate routes for OpenShift", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Check for Route resources
 			var hasKruizeRoute, hasUIRoute bool
@@ -1113,7 +1153,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate services for all cluster types", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Check for Service resources
 			var hasKruizeService, hasDBService, hasUIService bool
@@ -1142,7 +1184,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate service with correct ports for Kruize", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize service
 			kruizeService := findTypedResource[*corev1.Service](namespacedResources, "kruize", "", "")
@@ -1164,7 +1208,9 @@ var _ = Describe("Kruize Controller", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize UI service
 			kruizeUIService := findTypedResource[*corev1.Service](namespacedResources, "kruize-ui-nginx-service", "", "")
@@ -1186,7 +1232,9 @@ var _ = Describe("Kruize Controller", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB service
 			kruizeDBService := findTypedResource[*corev1.Service](namespacedResources, "kruize-db-service", "", "")
@@ -1207,7 +1255,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize service with NodePort type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize service
 			kruizeService := findTypedResource[*corev1.Service](namespacedResources, "kruize", "", "")
@@ -1218,7 +1268,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize UI service with NodePort type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize UI service
 			kruizeUIService := findTypedResource[*corev1.Service](namespacedResources, "kruize-ui-nginx-service", "", "")
@@ -1229,7 +1281,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should generate Kruize DB service with ClusterIP type", func() {
 			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
-			namespacedResources := generator.NamespacedResources()
+			coreResources := generator.CoreNamespacedResources()
+			optimizerResources := generator.OptimizerNamespacedResources()
+			namespacedResources := append(coreResources, optimizerResources...)
 
 			// Find the Kruize DB service
 			kruizeDBService := findTypedResource[*corev1.Service](namespacedResources, "kruize-db-service", "", "")
@@ -1255,7 +1309,9 @@ var _ = Describe("Kruize Controller", func() {
     			"Generator should default Autotune_ui_image when empty")
 
     		By("verifying the generated resources use default images")
-    		namespacedResources := generator.KubernetesNamespacedResources()
+    		coreResources := generator.CoreKubernetesNamespacedResources()
+    		optimizerResources := generator.OptimizerKubernetesNamespacedResources()
+    		namespacedResources := append(coreResources, optimizerResources...)
 
     		// Find and verify Kruize deployment using helper
     		kruizeDeployment := findTypedResource[*appsv1.Deployment](namespacedResources, "kruize", "app", "kruize")
@@ -1444,3 +1500,4 @@ var _ = Describe("Kruize Controller", func() {
         })
     })
 })
+

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -459,40 +459,35 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Resource generation", func() {
 		It("should generate cluster-scoped resources for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			clusterResources := generator.ClusterScopedResources()
 			Expect(clusterResources).NotTo(BeEmpty())
 			Expect(len(clusterResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate namespaced resources for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.NamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate Kubernetes cluster-scoped resources", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			clusterResources := generator.KubernetesClusterScopedResources()
 			Expect(clusterResources).NotTo(BeEmpty())
 			Expect(len(clusterResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should generate Kubernetes namespaced resources", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.KubernetesNamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
 			Expect(len(namespacedResources)).To(BeNumerically(">", 0))
 		})
 
 		It("should use default images when not specified", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			Expect(generator.Autotune_image).To(Equal(constants.GetDefaultAutotuneImage()))
 			Expect(generator.Autotune_ui_image).To(Equal(constants.GetDefaultUIImage()))
 		})
@@ -500,7 +495,9 @@ var _ = Describe("Kruize Controller", func() {
 		It("should use custom images when specified", func() {
 			customImage := "custom/image:v1.0"
 			customUIImage := "custom/ui:v1.0"
-			generator := utils.NewKruizeResourceGenerator("test-namespace", customImage, customUIImage, constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			customOptimizerImage := "custom/optimizer:v1.0"
+
+			generator := utils.NewKruizeResourceGenerator("test-namespace", customImage, customUIImage, customOptimizerImage, constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			Expect(generator.Autotune_image).To(Equal(customImage))
 			Expect(generator.Autotune_ui_image).To(Equal(customUIImage))
@@ -604,7 +601,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("RBAC and ConfigMap manifest generation", func() {
 		It("should generate RBAC manifests correctly for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -625,7 +622,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate RBAC manifests correctly for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -646,7 +644,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate ConfigMap correctly for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMap()
 			Expect(configMap).NotTo(BeNil())
@@ -656,8 +654,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate ConfigMap correctly for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			configMap := generator.KruizeConfigMapKubernetes()
 			Expect(configMap).NotTo(BeNil())
 			Expect(configMap.GetName()).To(Equal("kruizeconfig"))
@@ -668,7 +665,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Data source configuration validation", func() {
 		It("should have valid data source configuration in ConfigMap for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMap()
 			Expect(configMap.Data).To(HaveKey("kruizeconfigjson"))
@@ -679,7 +676,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should have valid data source configuration in ConfigMap for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			configMap := generator.KruizeConfigMapKubernetes()
 			Expect(configMap.Data).To(HaveKey("kruizeconfigjson"))
@@ -693,7 +690,8 @@ var _ = Describe("Kruize Controller", func() {
 	Context("Kruize deployment manifest generation", func() {
 		DescribeTable("should generate valid Kruize deployment manifest with default resources",
 			func(clusterType string, resourceMethod func(*utils.KruizeResourceGenerator) []client.Object) {
-				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 				namespacedResources := resourceMethod(generator)
 
 				// Check for Deployment resources and validate default resource configuration
@@ -766,7 +764,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Pod creation validation", func() {
 		It("should generate Kruize pod specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -776,7 +774,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-ui deployment specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift)
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift)
 
 			namespacedResources := generator.NamespacedResources()
 			
@@ -796,7 +794,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-db pod specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -809,7 +807,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("1.0", "2.0", "1Gi", "2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -830,7 +828,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("0.25", "1.0", "256Mi", "512Mi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -848,7 +846,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default resources when ResourceConfig is nil", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "",constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -869,7 +867,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("1.5", "", "", "3Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -894,7 +892,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("0.3", "", "", ""),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -914,7 +912,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				Kruize: createKruizeAppConfig("", "", "", "2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			namespacedResources := generator.KubernetesNamespacedResources()
 
@@ -934,7 +932,7 @@ var _ = Describe("Kruize Controller", func() {
 			customSpec := &kruizev1alpha1.KruizeSpec{
 				KruizeDB: createKruizeDBConfig("", "1.0", "256Mi", ""),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			namespacedResources := generator.KubernetesNamespacedResources()
 
@@ -959,7 +957,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume:      createPVSpec("2Gi", "custom-storage", "/custom/path", []kruizev1alpha1.PersistentVolumeAccessMode{kruizev1alpha1.ReadWriteOnce}),
 				PersistentVolumeClaim: createPVCSpec("1Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -984,7 +982,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume:      createPVSpec("3Gi", "k8s-storage", "/k8s/custom/path", []kruizev1alpha1.PersistentVolumeAccessMode{kruizev1alpha1.ReadWriteMany}),
 				PersistentVolumeClaim: createPVCSpec("2Gi"),
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1009,7 +1007,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume: createPVSpec("5Gi", "fallback-storage", "/fallback/path", nil),
 				// PVC not specified, should use PV storage size
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, customSpec, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -1030,7 +1028,7 @@ var _ = Describe("Kruize Controller", func() {
 				PersistentVolume: createPVSpec("4Gi", "k8s-fallback", "/k8s/fallback", nil),
 				// PVC not specified, should use PV storage size
 			}
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, customSpec, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1047,7 +1045,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default PV/PVC configuration when ResourceConfig is nil for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.ClusterScopedResources()
 
@@ -1068,7 +1066,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should use default PV/PVC configuration when ResourceConfig is nil for Kubernetes", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeMinikube, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			clusterResources := generator.KubernetesClusterScopedResources()
 
@@ -1091,8 +1089,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Route and service creation", func() {
 		It("should generate routes for OpenShift", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
-
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			namespacedResources := generator.NamespacedResources()
 
 			// Check for Route resources
@@ -1114,7 +1111,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate services for all cluster types", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1143,7 +1140,7 @@ var _ = Describe("Kruize Controller", func() {
 
 	Context("Kruize endpoints validation", func() {
 		It("should generate service with correct ports for Kruize", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1164,7 +1161,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate service with correct ports for Kruize UI", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1185,7 +1183,8 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate service with correct ports for Kruize DB", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1206,7 +1205,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize service with NodePort type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1217,7 +1216,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize UI service with NodePort type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1228,7 +1227,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize DB service with ClusterIP type", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 
@@ -1245,7 +1244,8 @@ var _ = Describe("Kruize Controller", func() {
     		clusterType := constants.ClusterTypeMinikube
 
     		By("creating a generator with empty image fields")
-    		generator := utils.NewKruizeResourceGenerator(namespace, "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+    		generator := utils.NewKruizeResourceGenerator(namespace, "", "", "", clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
     		By("verifying the generator uses the default-image helpers")
     		// This test verifies that the generator is wired to use the default-image helpers
@@ -1285,9 +1285,11 @@ var _ = Describe("Kruize Controller", func() {
     		clusterType := constants.ClusterTypeMinikube
     		customAutotuneImage := "custom.registry/autotune:custom-tag"
     		customUIImage := "custom.registry/ui:custom-tag"
+			customOptimizerImage := "custom.registry/optimizer:custom-tag"
 
     		By("creating a generator with custom image values")
-    		generator := utils.NewKruizeResourceGenerator(namespace, customAutotuneImage, customUIImage, clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+    		generator := utils.NewKruizeResourceGenerator(namespace, customAutotuneImage, customUIImage, customOptimizerImage, clusterType, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+
 
     		By("verifying the generator uses the provided custom images")
     		Expect(generator.Autotune_image).To(Equal(customAutotuneImage),

--- a/internal/controller/kruize_controller_test.go
+++ b/internal/controller/kruize_controller_test.go
@@ -520,7 +520,7 @@ var _ = Describe("Kruize Controller", func() {
 				},
 			}
 
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruize.Spec, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 			Expect(namespacedResources).NotTo(BeEmpty())
@@ -550,7 +550,7 @@ var _ = Describe("Kruize Controller", func() {
 
 		It("should allow partial resource overrides while preserving defaults", func() {
 			// First, generate resources with default configuration to capture default resources
-			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
+			defaultGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 			defaultNamespacedResources := defaultGenerator.NamespacedResources()
 
 			defaultKruizeDeployment := findDeployment(defaultNamespacedResources, "kruize")
@@ -569,7 +569,7 @@ var _ = Describe("Kruize Controller", func() {
 				KruizeDB: createKruizeDBConfig("250m", "", "", ""),
 				Kruize:   createKruizeAppConfig("300m", "", "", ""),
 			}
-			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
+			partialGenerator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, partialSpec, getTestContext())
 			partialNamespacedResources := partialGenerator.NamespacedResources()
 
 			partialKruizeDeployment := findDeployment(partialNamespacedResources, "kruize")
@@ -729,7 +729,7 @@ var _ = Describe("Kruize Controller", func() {
 					Kruize:   createKruizeAppConfig("2.0", "2.5", "1Gi", "1.5Gi"),
 					KruizeDB: createKruizeDBConfig("0.75", "1.5", "512Mi", "1Gi"),
 				}
-				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", clusterType, customSpec, getTestContext())
+				generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", clusterType, customSpec, getTestContext())
 				namespacedResources := resourceMethod(generator)
 
 				// Check for Deployment resources and validate custom resource configuration
@@ -774,7 +774,7 @@ var _ = Describe("Kruize Controller", func() {
 		})
 
 		It("should generate Kruize-ui deployment specification", func() {
-			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift)
+			generator := utils.NewKruizeResourceGenerator("test-namespace", "", "", "", constants.ClusterTypeOpenShift, &kruizev1alpha1.KruizeSpec{}, getTestContext())
 
 			namespacedResources := generator.NamespacedResources()
 			

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -517,6 +517,35 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 	return objects
 }
 
+// CoreNamespacedResources generates core Kruize resources (DB, Kruize, UI) without optimizer.
+// Deploy these first and wait for Kruize to be ready before deploying optimizer.
+func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
+	objects := []client.Object{
+		g.kruizeDBDeployment(),
+		g.kruizeDBService(),
+		g.kruizeDeployment(),
+		g.kruizeService(),
+		g.createPartitionCronJob(),
+		g.kruizeServiceMonitor(),
+		g.nginxConfigMap(),
+		g.kruizeUINginxService(),
+		g.kruizeUINginxPod(),
+		g.deletePartitionCronJob(),
+	}
+
+	objects = append(objects, g.Routes()...)
+	return objects
+}
+
+// OptimizerNamespacedResources generates optimizer-specific resources.
+// Deploy these after Kruize core is ready.
+func (g *KruizeResourceGenerator) OptimizerNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
+	}
+}
+
 func (g *KruizeResourceGenerator) Routes() []client.Object {
 	routes := []*routev1.Route{
 		g.generateRoute("kruize", "kruize", "kruize-port"),
@@ -1095,7 +1124,6 @@ func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment
 								{ContainerPort: 8080},
 							},
 							Env: []corev1.EnvVar{
-								{Name: "ENABLE_SWAGGER", Value: "true"},
 								{Name: "KRUIZE_URL", Value: "http://kruize:8080"},
 								{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: "60m"},
 								{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: "15m"},
@@ -1985,5 +2013,32 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 		g.kruizeUINginxService(),
 		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
+	}
+}
+
+// CoreKubernetesNamespacedResources returns core Kruize resources for Kubernetes without optimizer.
+// Deploy these first and wait for Kruize to be ready before deploying optimizer.
+func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeToPrometheusNetworkPolicy(),
+		g.kruizeDBDeploymentKubernetes(),
+		g.kruizeDBService(),
+		g.kruizeDeploymentKubernetes(),
+		g.kruizeServiceKubernetes(),
+		g.createPartitionCronJob(),
+		g.kruizeServiceMonitor(),
+		g.nginxConfigMap(),
+		g.kruizeUINginxService(),
+		g.kruizeUINginxPod(),
+		g.deletePartitionCronJob(),
+	}
+}
+
+// OptimizerKubernetesNamespacedResources returns optimizer-specific resources for Kubernetes.
+// Deploy these after Kruize core is ready.
+func (g *KruizeResourceGenerator) OptimizerKubernetesNamespacedResources() []client.Object {
+	return []client.Object{
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 	}
 }

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -34,22 +34,27 @@ type KruizeResourceGenerator struct {
 	Namespace         string
 	Autotune_image    string
 	Autotune_ui_image string
+	Optimizer_image   string
 	ClusterType       string // "openshift", "minikube", or "kind"
 	KruizeSpec        *kruizev1alpha1.KruizeSpec
 	Ctx               context.Context
 }
 
 // NewKruizeResourceGenerator creates a new generator for Kruize resources.
-func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string, clusterType string, kruizeSpec *kruizev1alpha1.KruizeSpec, ctx context.Context) *KruizeResourceGenerator {
+func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotuneUIImage string,  optimizerImage string, clusterType string, kruizeSpec *kruizev1alpha1.KruizeSpec, ctx context.Context) *KruizeResourceGenerator {
 	// If no image is provided from the CR, use a sensible default.
 	// The default can be configured via environment variables:
 	// - DEFAULT_AUTOTUNE_IMAGE: Override the default Autotune image
 	// - DEFAULT_AUTOTUNE_UI_IMAGE: Override the default Autotune UI image
+	// - DEFAULT_OPTIMIZER_IMAGE: Override the default Optimizer image
 	if autotuneImage == "" {
 		autotuneImage = constants.GetDefaultAutotuneImage()
 	}
 	if autotuneUIImage == "" {
 		autotuneUIImage = constants.GetDefaultUIImage()
+	}
+	if optimizerImage == "" {
+		optimizerImage = constants.GetDefaultOptimizerImage()
 	}
 	if clusterType == "" {
 		clusterType = constants.ClusterTypeOpenShift // Default to openshift for backward compatibility
@@ -58,6 +63,7 @@ func NewKruizeResourceGenerator(namespace string, autotuneImage string, autotune
 		Namespace:         namespace,
 		Autotune_image:    autotuneImage,
 		Autotune_ui_image: autotuneUIImage,
+		Optimizer_image:   optimizerImage,
 		ClusterType:       clusterType,
 		KruizeSpec:        kruizeSpec,
 		Ctx:               ctx,
@@ -498,6 +504,8 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 		g.kruizeDBService(),
 		g.kruizeDeployment(),
 		g.kruizeService(),
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 		g.createPartitionCronJob(),
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
@@ -1047,6 +1055,93 @@ func (g *KruizeResourceGenerator) kruizeService() *corev1.Service {
 			},
 		},
 	}
+// kruizeOptimizerDeployment generates the Deployment for the Kruize Optimizer.
+func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment {
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kruize-optimizer",
+			Namespace: g.Namespace,
+			Labels: map[string]string{
+				"app": "kruize-optimizer",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "kruize-optimizer",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "kruize-optimizer",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "kruize-optimizer",
+							Image:           g.Optimizer_image,
+							ImagePullPolicy: corev1.PullAlways,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: 8080},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "ENABLE_SWAGGER", Value: "true"},
+								{Name: "KRUIZE_URL", Value: "http://kruize:8080"},
+								{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: "60m"},
+								{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: "15m"},
+								{Name: "KRUIZE_BULK_SCHEDULER_STARTUP_DELAY", Value: "1m"},
+								{Name: "KRUIZE_BULK_MEASUREMENT_DURATION", Value: "15min"},
+								{Name: "KRUIZE_WEBHOOK_URL", Value: "http://kruize-optimizer:8080/webhook"},
+								{Name: "KRUIZE_TARGET_LABEL_LIMIT", Value: "1"},
+								{Name: "KRUIZE_TARGET_LABELS", Value: `{"kruize/autotune": "enabled"}`},
+								{Name: "KRUIZE_DEFAULT_DATASOURCE", Value: "prometheus-1"},
+								{Name: "KRUIZE_DEFAULT_METADATA_PROFILE", Value: "cluster-metadata-local-monitoring"},
+								{Name: "KRUIZE_DEFAULT_METRIC_PROFILE", Value: "resource-optimization-local-monitoring"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// kruizeOptimizerService generates the Service for the Kruize Optimizer.
+func (g *KruizeResourceGenerator) kruizeOptimizerService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kruize-optimizer",
+			Namespace: g.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app": "kruize-optimizer",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	}
+}
+
 }
 
 
@@ -1884,6 +1979,8 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 		g.kruizeDBService(),
 		g.kruizeDeploymentKubernetes(),
 		g.kruizeServiceKubernetes(),
+		g.kruizeOptimizerDeployment(),
+		g.kruizeOptimizerService(),
 		g.createPartitionCronJob(),
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -97,6 +97,74 @@ func (g *KruizeResourceGenerator) parseResourceQuantity(value, defaultValue stri
 	return resource.MustParse(defaultValue)
 }
 
+// getOptimizerEnvVars returns optimizer environment variables with defaults
+func (g *KruizeResourceGenerator) getOptimizerEnvVars() []corev1.EnvVar {
+	// Default values
+	kruizeURL := "http://kruize:8080"
+	stateRefreshInterval := "60m"
+	bulkSchedulerInterval := "15m"
+	bulkSchedulerStartupDelay := "1m"
+	bulkMeasurementDuration := "15min"
+	webhookURL := "http://kruize-optimizer:8080/webhook"
+	targetLabelLimit := "1"
+	targetLabels := `{"kruize/autotune": "enabled"}`
+	defaultDatasource := "prometheus-1"
+	defaultMetadataProfile := "cluster-metadata-local-monitoring"
+	defaultMetricProfile := "resource-optimization-local-monitoring"
+
+	// Override with values from CR if provided
+	if g.KruizeSpec != nil && g.KruizeSpec.Optimizer != nil {
+		opt := g.KruizeSpec.Optimizer
+		if opt.KruizeURL != "" {
+			kruizeURL = opt.KruizeURL
+		}
+		if opt.StateRefreshInterval != "" {
+			stateRefreshInterval = opt.StateRefreshInterval
+		}
+		if opt.BulkSchedulerInterval != "" {
+			bulkSchedulerInterval = opt.BulkSchedulerInterval
+		}
+		if opt.BulkSchedulerStartupDelay != "" {
+			bulkSchedulerStartupDelay = opt.BulkSchedulerStartupDelay
+		}
+		if opt.BulkMeasurementDuration != "" {
+			bulkMeasurementDuration = opt.BulkMeasurementDuration
+		}
+		if opt.WebhookURL != "" {
+			webhookURL = opt.WebhookURL
+		}
+		if opt.TargetLabelLimit != "" {
+			targetLabelLimit = opt.TargetLabelLimit
+		}
+		if opt.TargetLabels != "" {
+			targetLabels = opt.TargetLabels
+		}
+		if opt.DefaultDatasource != "" {
+			defaultDatasource = opt.DefaultDatasource
+		}
+		if opt.DefaultMetadataProfile != "" {
+			defaultMetadataProfile = opt.DefaultMetadataProfile
+		}
+		if opt.DefaultMetricProfile != "" {
+			defaultMetricProfile = opt.DefaultMetricProfile
+		}
+	}
+
+	return []corev1.EnvVar{
+		{Name: "KRUIZE_URL", Value: kruizeURL},
+		{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: stateRefreshInterval},
+		{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: bulkSchedulerInterval},
+		{Name: "KRUIZE_BULK_SCHEDULER_STARTUP_DELAY", Value: bulkSchedulerStartupDelay},
+		{Name: "KRUIZE_BULK_MEASUREMENT_DURATION", Value: bulkMeasurementDuration},
+		{Name: "KRUIZE_WEBHOOK_URL", Value: webhookURL},
+		{Name: "KRUIZE_TARGET_LABEL_LIMIT", Value: targetLabelLimit},
+		{Name: "KRUIZE_TARGET_LABELS", Value: targetLabels},
+		{Name: "KRUIZE_DEFAULT_DATASOURCE", Value: defaultDatasource},
+		{Name: "KRUIZE_DEFAULT_METADATA_PROFILE", Value: defaultMetadataProfile},
+		{Name: "KRUIZE_DEFAULT_METRIC_PROFILE", Value: defaultMetricProfile},
+	}
+}
+
 // getDBResources returns database resource requirements with defaults
 // For minikube/kind, defaults are disabled unless explicitly specified in the CR
 func (g *KruizeResourceGenerator) getDBResources() corev1.ResourceRequirements {
@@ -1118,19 +1186,7 @@ func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment
 							Ports: []corev1.ContainerPort{
 								{ContainerPort: 8080},
 							},
-							Env: []corev1.EnvVar{
-								{Name: "KRUIZE_URL", Value: "http://kruize:8080"},
-								{Name: "KRUIZE_STATE_REFRESH_INTERVAL", Value: "60m"},
-								{Name: "KRUIZE_BULK_SCHEDULER_INTERVAL", Value: "15m"},
-								{Name: "KRUIZE_BULK_SCHEDULER_STARTUP_DELAY", Value: "1m"},
-								{Name: "KRUIZE_BULK_MEASUREMENT_DURATION", Value: "15min"},
-								{Name: "KRUIZE_WEBHOOK_URL", Value: "http://kruize-optimizer:8080/webhook"},
-								{Name: "KRUIZE_TARGET_LABEL_LIMIT", Value: "1"},
-								{Name: "KRUIZE_TARGET_LABELS", Value: `{"kruize/autotune": "enabled"}`},
-								{Name: "KRUIZE_DEFAULT_DATASOURCE", Value: "prometheus-1"},
-								{Name: "KRUIZE_DEFAULT_METADATA_PROFILE", Value: "cluster-metadata-local-monitoring"},
-								{Name: "KRUIZE_DEFAULT_METRIC_PROFILE", Value: "resource-optimization-local-monitoring"},
-							},
+							Env: g.getOptimizerEnvVars(),
 						},
 					},
 				},

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -521,6 +521,7 @@ func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
 	objects := []client.Object{
+		g.kruizeDBPersistentVolumeClaim(),
 		g.kruizeDBDeployment(),
 		g.kruizeDBService(),
 		g.kruizeDeployment(),
@@ -2037,6 +2038,7 @@ func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Objec
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.Object {
 	return []client.Object{
+		g.kruizeDBPersistentVolumeClaimKubernetes(),
 		g.kruizeToPrometheusNetworkPolicy(),
 		g.kruizeDBDeploymentKubernetes(),
 		g.kruizeDBService(),

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -494,29 +494,6 @@ func (g *KruizeResourceGenerator) ClusterScopedResources() []client.Object {
 	}
 }
 
-// NamespacedResources generates all OpenShift namespaced resources for Kruize.
-// These resources will get an owner reference set to the Kruize CR.
-func (g *KruizeResourceGenerator) NamespacedResources() []client.Object {
-	objects := []client.Object{
-		g.kruizeDBPersistentVolumeClaim(),
-		g.kruizeDBDeployment(),
-		g.kruizeDBService(),
-		g.kruizeDeployment(),
-		g.kruizeService(),
-		g.kruizeOptimizerDeployment(),
-		g.kruizeOptimizerService(),
-		g.createPartitionCronJob(),
-		g.kruizeServiceMonitor(),
-		g.nginxConfigMap(),
-		g.kruizeUINginxService(),
-		g.kruizeUINginxDeployment(),
-		g.deletePartitionCronJob(),
-	}
-
-	objects = append(objects, g.Routes()...)
-	return objects
-}
-
 // CoreNamespacedResources generates core Kruize resources (DB, Kruize, UI) without optimizer.
 // Deploy these first and wait for Kruize to be ready before deploying optimizer.
 func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
@@ -2011,26 +1988,6 @@ func (g *KruizeResourceGenerator) KubernetesClusterScopedResources() []client.Ob
 		g.instaslicesAccessClusterRoleBindingKubernetes(),
 		g.kruizeEditKOClusterRoleBindingKubernetes(),
 		g.kruizeDBPersistentVolumeKubernetes(),
-	}
-}
-
-// KubernetesNamespacedResources returns namespaced resources for Kind/minikube/Kubernetes
-func (g *KruizeResourceGenerator) KubernetesNamespacedResources() []client.Object {
-	return []client.Object{
-		g.kruizeDBPersistentVolumeClaimKubernetes(),
-		g.kruizeToPrometheusNetworkPolicy(),
-		g.kruizeDBDeploymentKubernetes(),
-		g.kruizeDBService(),
-		g.kruizeDeploymentKubernetes(),
-		g.kruizeServiceKubernetes(),
-		g.kruizeOptimizerDeployment(),
-		g.kruizeOptimizerService(),
-		g.createPartitionCronJob(),
-		g.kruizeServiceMonitor(),
-		g.nginxConfigMap(),
-		g.kruizeUINginxService(),
-		g.kruizeUINginxDeployment(),
-		g.deletePartitionCronJob(),
 	}
 }
 

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -1115,6 +1115,23 @@ func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment
 					},
 				},
 				Spec: corev1.PodSpec{
+					// Init container to wait for Kruize deployment to be ready
+					InitContainers: []corev1.Container{
+						{
+							Name:  "wait-for-kruize",
+							Image: "busybox:1.36",
+							Command: []string{
+								"sh",
+								"-c",
+								`echo "Waiting for Kruize service to be ready...";
+								until wget -q -O- --timeout=5 http://kruize:8080/health >/dev/null 2>&1 || wget -q -O- --timeout=5 http://kruize:8080 >/dev/null 2>&1; do
+								echo "Kruize service not ready yet, waiting...";
+								sleep 5;
+								done;
+								echo "Kruize service is ready!";`,
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "kruize-optimizer",

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -529,7 +529,7 @@ func (g *KruizeResourceGenerator) CoreNamespacedResources() []client.Object {
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
 		g.kruizeUINginxService(),
-		g.kruizeUINginxPod(),
+		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
 	}
 
@@ -2046,7 +2046,7 @@ func (g *KruizeResourceGenerator) CoreKubernetesNamespacedResources() []client.O
 		g.kruizeServiceMonitor(),
 		g.nginxConfigMap(),
 		g.kruizeUINginxService(),
-		g.kruizeUINginxPod(),
+		g.kruizeUINginxDeployment(),
 		g.deletePartitionCronJob(),
 	}
 }

--- a/internal/utils/kruize_generator.go
+++ b/internal/utils/kruize_generator.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-
 	kruizev1alpha1 "github.com/kruize/kruize-operator/api/v1alpha1"
 	"github.com/kruize/kruize-operator/internal/constants"
 	routev1 "github.com/openshift/api/route/v1"
@@ -1055,6 +1054,8 @@ func (g *KruizeResourceGenerator) kruizeService() *corev1.Service {
 			},
 		},
 	}
+}
+
 // kruizeOptimizerDeployment generates the Deployment for the Kruize Optimizer.
 func (g *KruizeResourceGenerator) kruizeOptimizerDeployment() *appsv1.Deployment {
 	replicas := int32(1)
@@ -1141,9 +1142,6 @@ func (g *KruizeResourceGenerator) kruizeOptimizerService() *corev1.Service {
 		},
 	}
 }
-
-}
-
 
 func (g *KruizeResourceGenerator) kruizeUINginxDeployment() *appsv1.Deployment {
 	replicas := int32(1)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -332,6 +332,19 @@ var _ = Describe("controller", Ordered, func() {
 				return err
 			}, 3*time.Minute, 10*time.Second).Should(Succeed())
 
+			By("checking that Kruize Optimizer deployment is ready")
+			Eventually(func() error {
+				cmd := exec.Command("kubectl", "get", "deployment", "kruize-optimizer", "-n", namespace, "-o", "jsonpath={.status.readyReplicas}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return err
+				}
+				if string(output) != "1" {
+					return fmt.Errorf("kruize-optimizer deployment not ready")
+				}
+				return nil
+			}, 3*time.Minute, 10*time.Second).Should(Succeed())
+
 			By("checking that datasource is configured via Kruize API")
 			var datasourceOutput string
 			Eventually(func() error {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable Kruize Optimizer component and integrate it into the operator’s deployment flow alongside existing Kruize services.

New Features:
- Add Kruize Optimizer deployment and service generation with configurable image and runtime settings via the Kruize custom resource.
- Expose optimizer-specific configuration and image fields in the Kruize CRD and sample manifest, including environment-driven defaults for the optimizer image.
- Provide separate generation paths for core Kruize resources and optimizer resources for both OpenShift and Kubernetes clusters.

Enhancements:
- Extend the resource generator and reconciler logic to deploy components in phases and wait for all Kruize-related pods, including the optimizer, to be ready.

Tests:
- Update controller unit tests to cover optimizer-aware resource generation and phased core/optimizer resource handling.
- Extend end-to-end tests to verify that the Kruize Optimizer deployment becomes ready after installation.