### PR TITLE
Update bundle manifests and bump kruize-operator to 0.0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,17 +294,23 @@ endif
 
 .PHONY: operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
-	@if [ "$(OPERATOR_SDK)" = "$(LOCALBIN)/operator-sdk" ] && [ ! -f $(OPERATOR_SDK) ]; then \
-		echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
-		mkdir -p $(LOCALBIN) ;\
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
-		case $$ARCH in \
-			x86_64) ARCH=amd64 ;; \
-			aarch64) ARCH=arm64 ;; \
-		esac ;\
-		curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-		chmod +x $(OPERATOR_SDK) ;\
-		echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\
+	@if [ ! -f $(OPERATOR_SDK) ]; then \
+		if [ "$(OPERATOR_SDK)" = "$(LOCALBIN)/operator-sdk" ]; then \
+			echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
+			mkdir -p $(LOCALBIN) ;\
+			OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
+			case $$ARCH in \
+				x86_64) ARCH=amd64 ;; \
+				aarch64) ARCH=arm64 ;; \
+			esac ;\
+			curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+			chmod +x $(OPERATOR_SDK) ;\
+			echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\
+		else \
+			echo "Error: Custom OPERATOR_SDK path '$(OPERATOR_SDK)' does not exist." ;\
+			echo "Please ensure the binary exists at the specified path or use the default location." ;\
+			exit 1 ;\
+		fi ;\
 	else \
 		echo "Using operator-sdk: $(OPERATOR_SDK)" ;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.4)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.4)
+# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.5)
+# - use environment variables to overwrite this value (e.g export VERSION=0.0.5)
 VERSION ?= 0.0.5
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.4)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.4)
-VERSION ?= 0.0.4
+VERSION ?= 0.0.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -285,26 +285,28 @@ mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef
 
-.PHONY: operator-sdk
+# Check if operator-sdk exists system-wide first, otherwise use local bin
+ifeq (,$(shell which operator-sdk 2>/dev/null))
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-operator-sdk: $(LOCALBIN) ## Download operator-sdk locally if necessary.
-	@if [ ! -f $(OPERATOR_SDK) ]; then \
-		if ! command -v operator-sdk >/dev/null 2>&1; then \
-			echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
-			mkdir -p $(dir $(OPERATOR_SDK)) ;\
-			OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
-			case $$ARCH in \
-				x86_64) ARCH=amd64 ;; \
-				aarch64) ARCH=arm64 ;; \
-			esac ;\
-			curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-			chmod +x $(OPERATOR_SDK) ;\
-			echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\
-		else \
-			echo "Using system operator-sdk: $$(which operator-sdk)" ;\
-		fi \
+else
+OPERATOR_SDK ?= $(shell which operator-sdk)
+endif
+
+.PHONY: operator-sdk
+operator-sdk: ## Download operator-sdk locally if necessary.
+	@if [ "$(OPERATOR_SDK)" = "$(LOCALBIN)/operator-sdk" ] && [ ! -f $(OPERATOR_SDK) ]; then \
+		echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)..." ;\
+		mkdir -p $(LOCALBIN) ;\
+		OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && ARCH=$$(uname -m) ;\
+		case $$ARCH in \
+			x86_64) ARCH=amd64 ;; \
+			aarch64) ARCH=arm64 ;; \
+		esac ;\
+		curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+		chmod +x $(OPERATOR_SDK) ;\
+		echo "operator-sdk downloaded to $(OPERATOR_SDK)" ;\
 	else \
-		echo "operator-sdk already exists at $(OPERATOR_SDK)" ;\
+		echo "Using operator-sdk: $(OPERATOR_SDK)" ;\
 	fi
 
 .PHONY: bundle

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -15,23 +15,94 @@ metadata:
             "name": "kruize-sample"
           },
           "spec": {
-            "autotune_image": "quay.io/kruize/autotune_operator:0.8.1",
-            "autotune_ui_image": "quay.io/kruize/kruize-ui:0.0.9",
+            "autotune_image": "quay.io/kruize/autotune_operator:0.9",
+            "autotune_ui_image": "quay.io/kruize/kruize-ui:0.1.0",
             "cluster_type": "openshift",
-            "namespace": "openshift-tuning"
+            "kruize": {
+              "resources": {
+                "limits": {
+                  "cpu": "0.7",
+                  "memory": "768Mi"
+                },
+                "requests": {
+                  "cpu": "0.7",
+                  "memory": "768Mi"
+                }
+              }
+            },
+            "kruize-db": {
+              "resources": {
+                "limits": {
+                  "cpu": "0.5",
+                  "memory": "100Mi"
+                },
+                "requests": {
+                  "cpu": "0.5",
+                  "memory": "100Mi"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/lib/pgsql/data",
+                  "name": "kruize-db-storage"
+                }
+              ],
+              "volumes": [
+                {
+                  "name": "kruize-db-storage",
+                  "persistentVolumeClaim": {
+                    "claimName": "kruize-db-pv-claim"
+                  }
+                }
+              ]
+            },
+            "namespace": "openshift-tuning",
+            "optimizer_image": "quay.io/kruize/kruize-optimizer:0.0.1",
+            "persistentVolume": {
+              "accessModes": [
+                "ReadWriteMany"
+              ],
+              "capacity": {
+                "storage": "500Mi"
+              },
+              "hostPath": {
+                "path": "/mnt/data"
+              },
+              "labels": {
+                "app": "kruize-db",
+                "type": "local"
+              },
+              "name": "kruize-db-pv-volume",
+              "storageClassName": "manual"
+            },
+            "persistentVolumeClaim": {
+              "accessModes": [
+                "ReadWriteMany"
+              ],
+              "labels": {
+                "app": "kruize-db"
+              },
+              "name": "kruize-db-pv-claim",
+              "resources": {
+                "requests": {
+                  "storage": "500Mi"
+                }
+              },
+              "storageClassName": "manual"
+            }
           }
         }
       ]
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.4
-    createdAt: "2026-02-04T08:25:45Z"
+    containerImage: quay.io/kruize/kruize-operator:0.0.5
+    createdAt: "2026-04-14T10:36:45Z"
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/kruize/kruize-operator
     support: Kruize Community
-  name: kruize-operator.v0.0.4
+  name: kruize-operator.v0.0.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -86,6 +157,11 @@ spec:
       - description: Target namespace for Kruize deployment
         displayName: Namespace
         path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Container image for Kruize Optimizer
+        displayName: Optimizer Image
+        path: optimizer_image
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
@@ -270,6 +346,18 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
         - apiGroups:
           - autoscaling.k8s.io
           resources:
@@ -492,30 +580,10 @@ spec:
           - get
           - list
           - watch
-        - apiGroups:
-          - autoscaling
-          resources:
-          - horizontalpodautoscalers
-          verbs:
-          - get
-          - list
-          - watch
         - nonResourceURLs:
           - /metrics
           verbs:
           - get
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
         serviceAccountName: kruize-operator-controller-manager
       deployments:
       - label:
@@ -538,35 +606,12 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=:8443
                 command:
                 - /app/manager
-                image: quay.io/kruize/kruize-operator:0.0.4
+                image: quay.io/kruize/kruize-operator:0.0.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -574,6 +619,13 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8443
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8081
+                  name: health-probe
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -663,4 +715,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Kruize
-  version: 0.0.4
+  version: 0.0.5

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -194,6 +194,14 @@ spec:
     - **cluster_type**: Set to `"openshift"`, `"minikube"`, or `"kind"` based on your environment
     - **namespace**: Namespace where Kruize components will be deployed
 
+    **Optional Fields (for minikube/kind clusters):**
+    - **kruize.resources**: Resource limits and requests for Kruize container
+    - **kruize-db.resources**: Resource limits and requests for Kruize database container
+    - **persistentVolume**: PersistentVolume configuration for database storage
+    - **persistentVolumeClaim**: PersistentVolumeClaim configuration for database storage
+
+    Note: Resource configurations, PersistentVolume, and PersistentVolumeClaim can be omitted for minikube/kind clusters for local development.
+
     ### Recommended Namespaces
     - **OpenShift clusters**: Use **openshift-tuning** namespace
       ```bash

--- a/bundle/manifests/kruize.io_kruizes.yaml
+++ b/bundle/manifests/kruize.io_kruizes.yaml
@@ -51,9 +51,193 @@ spec:
               cluster_type:
                 description: Type of Kubernetes cluster (openshift, minikube, or kind)
                 type: string
+              kruize:
+                description: Kruize application resource configuration
+                properties:
+                  resources:
+                    description: Resource requirements
+                    properties:
+                      limits:
+                        description: Resource limits
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Resource requests
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              kruize-db:
+                description: Database resource configuration
+                properties:
+                  resources:
+                    description: Resource requirements
+                    properties:
+                      limits:
+                        description: Resource limits
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Resource requests
+                        properties:
+                          cpu:
+                            description: CPU (e.g., "0.5", "500m")
+                            type: string
+                          memory:
+                            description: Memory (e.g., "100Mi", "1Gi")
+                            type: string
+                        type: object
+                    type: object
+                  volumeMounts:
+                    description: Volume mounts for the container
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted
+                          type: string
+                        name:
+                          description: Name of the volume to mount
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes for the pod
+                    items:
+                      description: Volume represents a named volume in a pod
+                      properties:
+                        name:
+                          description: Name of the volume
+                          type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaim represents a reference
+                            to a PersistentVolumeClaim
+                          properties:
+                            claimName:
+                              description: ClaimName is the name of the PVC in the
+                                same namespace
+                              type: string
+                          required:
+                          - claimName
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
               namespace:
                 description: Target namespace for Kruize deployment
                 type: string
+              optimizer_image:
+                description: Container image for Kruize Optimizer
+                type: string
+              persistentVolume:
+                description: Persistent Volume configuration
+                properties:
+                  accessModes:
+                    description: Access modes for the persistent volume
+                    items:
+                      description: PersistentVolumeAccessMode defines the access mode
+                        for persistent volumes
+                      enum:
+                      - ReadWriteOnce
+                      - ReadOnlyMany
+                      - ReadWriteMany
+                      - ReadWriteOncePod
+                      type: string
+                    maxItems: 4
+                    type: array
+                  capacity:
+                    description: Capacity defines the storage capacity
+                    properties:
+                      storage:
+                        description: Storage size (e.g., "500Mi", "1Gi")
+                        type: string
+                    type: object
+                  hostPath:
+                    description: Host path configuration
+                    properties:
+                      path:
+                        description: Path of the directory on the host
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels for the PersistentVolume
+                    type: object
+                  name:
+                    description: Name of the PersistentVolume
+                    type: string
+                  storageClassName:
+                    description: Storage class name
+                    type: string
+                type: object
+              persistentVolumeClaim:
+                description: Persistent Volume Claim configuration
+                properties:
+                  accessModes:
+                    description: Access modes for the persistent volume claim
+                    items:
+                      description: PersistentVolumeAccessMode defines the access mode
+                        for persistent volumes
+                      enum:
+                      - ReadWriteOnce
+                      - ReadOnlyMany
+                      - ReadWriteMany
+                      - ReadWriteOncePod
+                      type: string
+                    maxItems: 4
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels for the PersistentVolumeClaim
+                    type: object
+                  name:
+                    description: Name of the PersistentVolumeClaim
+                    type: string
+                  resources:
+                    description: Resources defines the storage resources
+                    properties:
+                      requests:
+                        description: Requests describes the minimum storage resources
+                          required
+                        properties:
+                          storage:
+                            description: Storage size (e.g., "500Mi", "1Gi")
+                            type: string
+                        type: object
+                    type: object
+                  storageClassName:
+                    description: Storage class name
+                    type: string
+                type: object
             required:
             - autotune_image
             - autotune_ui_image

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kruize/kruize-operator
-  newTag: 0.0.4
+  newTag: 0.0.5

--- a/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.4
+    containerImage: quay.io/kruize/kruize-operator:0.0.5
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -66,6 +66,11 @@ spec:
       - description: Target namespace for Kruize deployment
         displayName: Namespace
         path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Container image for Kruize Optimizer
+        displayName: Optimizer Image
+        path: optimizer_image
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1


### PR DESCRIPTION
This PR updates the bundle manifests and bumps kruize-operator version to 0.0.5

#### Major Changes:

- Removed deprecated kube-rbac-proxy sidecar container from bundle manifests
- Updated operator image to `quay.io/kruize/kruize-operator:0.0.5`
- Updates to `kruize.io_kruizes.yaml `with new Optimizer, PV, PVC, Kruize, KruizeDB resource config fields added in the Kruize custom resource
- Updated Makefile to handle operator-sdk installation properly

## Summary by Sourcery

Bump the kruize-operator release to 0.0.5 and update associated manifests and tooling accordingly.

New Features:
- Extend the Kruize custom resource schema and CSV example to support configurable optimizer image, resource settings, and persistent storage for the Kruize application and database.

Enhancements:
- Update operator bundle and CSV metadata, including container image references, sample images, permissions, and version fields to align with kruize-operator 0.0.5 and newer component images.
- Expose the optimizer image as a configurable field in both bundle and base ClusterServiceVersion manifests and adjust manager container ports to serve metrics and health checks directly without the kube-rbac-proxy sidecar.

Build:
- Bump the default operator VERSION from 0.0.4 to 0.0.5 and refine the Makefile operator-sdk target to prefer a system-wide binary and only download a local copy when necessary.

Chores:
- Remove the deprecated kube-rbac-proxy sidecar container and its related RBAC rules from the operator deployment in the CSV.