### PR TITLE
Update bundle files and bump kruize-operator 0.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.5)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.5)
-VERSION ?= 0.0.5
+VERSION ?= 0.0.6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -194,13 +194,15 @@ spec:
     - **cluster_type**: Set to `"openshift"`, `"minikube"`, or `"kind"` based on your environment
     - **namespace**: Namespace where Kruize components will be deployed
 
-    **Optional Fields (for minikube/kind clusters):**
+    **Optional resource and storage fields (applicable to all cluster types):**
     - **kruize.resources**: Resource limits and requests for Kruize container
     - **kruize-db.resources**: Resource limits and requests for Kruize database container
     - **persistentVolume**: PersistentVolume configuration for database storage
     - **persistentVolumeClaim**: PersistentVolumeClaim configuration for database storage
 
-    Note: Resource configurations, PersistentVolume, and PersistentVolumeClaim can be omitted for minikube/kind clusters for local development.
+    Note: For local development on **minikube/kind** clusters, these resource configurations, PersistentVolume, and
+    PersistentVolumeClaim can be omitted. For other environments (including **OpenShift**) and non-local/minikube/kind
+    setups, configuring these fields is recommended.
 
     ### Recommended Namespaces
     - **OpenShift clusters**: Use **openshift-tuning** namespace

--- a/bundle/manifests/kruize-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kruize-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
             "name": "kruize-sample"
           },
           "spec": {
-            "autotune_image": "quay.io/kruize/autotune_operator:0.9",
+            "autotune_image": "quay.io/kruize/autotune_operator:0.10",
             "autotune_ui_image": "quay.io/kruize/kruize-ui:0.1.0",
             "cluster_type": "openshift",
             "kruize": {
@@ -95,14 +95,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.5
-    createdAt: "2026-04-14T10:36:45Z"
+    containerImage: quay.io/kruize/kruize-operator:0.0.6
+    createdAt: "2026-05-11T11:14:38Z"
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/kruize/kruize-operator
     support: Kruize Community
-  name: kruize-operator.v0.0.5
+  name: kruize-operator.v0.0.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -619,7 +619,7 @@ spec:
                 - --metrics-bind-address=:8443
                 command:
                 - /app/manager
-                image: quay.io/kruize/kruize-operator:0.0.5
+                image: quay.io/kruize/kruize-operator:0.0.6
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -723,4 +723,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Kruize
-  version: 0.0.5
+  version: 0.0.6

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kruize/kruize-operator
-  newTag: 0.0.5
+  newTag: 0.0.6

--- a/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/kruize/kruize-operator:0.0.5
+    containerImage: quay.io/kruize/kruize-operator:0.0.6
     description: Resource optimization tool for Kubernetes workloads
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -102,6 +102,14 @@ spec:
     **Required Fields:**
     - **cluster_type**: Set to `"openshift"`, `"minikube"`, or `"kind"` based on your environment
     - **namespace**: Namespace where Kruize components will be deployed
+
+    **Optional Fields (for minikube/kind clusters):**
+    - **kruize.resources**: Resource limits and requests for Kruize container
+    - **kruize-db.resources**: Resource limits and requests for Kruize database container
+    - **persistentVolume**: PersistentVolume configuration for database storage
+    - **persistentVolumeClaim**: PersistentVolumeClaim configuration for database storage
+
+    Note: Resource configurations, PersistentVolume, and PersistentVolumeClaim can be omitted for minikube/kind clusters for local development.
 
     ### Recommended Namespaces
     - **OpenShift clusters**: Use **openshift-tuning** namespace

--- a/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kruize-operator.clusterserviceversion.yaml
@@ -103,13 +103,15 @@ spec:
     - **cluster_type**: Set to `"openshift"`, `"minikube"`, or `"kind"` based on your environment
     - **namespace**: Namespace where Kruize components will be deployed
 
-    **Optional Fields (for minikube/kind clusters):**
+    **Optional resource and storage fields (applicable to all cluster types):**
     - **kruize.resources**: Resource limits and requests for Kruize container
     - **kruize-db.resources**: Resource limits and requests for Kruize database container
     - **persistentVolume**: PersistentVolume configuration for database storage
     - **persistentVolumeClaim**: PersistentVolumeClaim configuration for database storage
 
-    Note: Resource configurations, PersistentVolume, and PersistentVolumeClaim can be omitted for minikube/kind clusters for local development.
+    Note: For local development on **minikube/kind** clusters, these resource configurations, PersistentVolume, and
+    PersistentVolumeClaim can be omitted. For other environments (including **OpenShift**) and non-local/minikube/kind
+    setups, configuring these fields is recommended.
 
     ### Recommended Namespaces
     - **OpenShift clusters**: Use **openshift-tuning** namespace


### PR DESCRIPTION
This PR updates the bundle manifests and bumps kruize-operator version to 0.0.6

Major Changes:

- Fixed CVE vulnerabilities observed with `0.0.5` image
- Bump `quay.io/kruize/autotune_operator` image to latest `0.10`
- Updated operator image to `quay.io/kruize/kruize-operator:0.0.6`

## Summary by Sourcery

Bump the kruize-operator release to 0.0.6 and update related bundle metadata and images.

Enhancements:
- Update kruize-operator container image references in manifests and manager config from 0.0.5 to 0.0.6.
- Upgrade the default autotune image used by the sample custom resource to quay.io/kruize/autotune_operator:0.10.
- Document optional resource and storage configuration fields for minikube/kind clusters in the operator CSV description.

Build:
- Bump the default VERSION in the Makefile from 0.0.5 to 0.0.6 for bundle generation.