### PR TITLE
Consolidate RBAC rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - persistentvolumeclaims
-  - persistentvolumes
   - pods
   - serviceaccounts
   - services
@@ -38,44 +37,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumes
   verbs:
   - create
   - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - create
   - get
   - list
   - watch
@@ -244,15 +209,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
   verbs:
   - create
@@ -263,7 +219,6 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterroles
   - rolebindings
   verbs:
   - create


### PR DESCRIPTION
This PR removes duplicate/redundant RBAC permission entries from `role.yaml,` updated using `make manifests` cmd.

## Summary by Sourcery

Enhancements:
- Remove duplicate RBAC rules for core resources such as namespaces, nodes, persistentvolumeclaims, pods, and clusterroles to reduce redundancy in role.yaml.