### PR TITLE
PR check: wait for Prometheus CRDs to be established before applying manifests

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -102,6 +102,13 @@ jobs:
             echo "Info: Installing prometheus setup"
             kubectl apply -f setup --server-side
           
+            echo "Info: Waiting for Prometheus CRDs to be established..."
+            kubectl wait \
+              --for=condition=Established \
+              --all \
+              --timeout=120s \
+              customresourcedefinitions.apiextensions.k8s.io
+
             echo "Info: Installing prometheus manifests"
             kubectl apply -f . --server-side
           

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -103,11 +103,17 @@ jobs:
             kubectl apply -f setup --server-side
           
             echo "Info: Waiting for Prometheus CRDs to be established..."
-            kubectl wait \
-              --for=condition=Established \
-              --all \
-              --timeout=120s \
-              customresourcedefinitions.apiextensions.k8s.io
+            kubectl wait --for=condition=Established --timeout=120s \
+              customresourcedefinitions.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/podmonitors.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/probes.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/prometheuses.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/prometheusagents.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/scrapeconfigs.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com \
+              customresourcedefinitions.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com
 
             echo "Info: Installing prometheus manifests"
             kubectl apply -f . --server-side


### PR DESCRIPTION
Add a CRD readiness gate in the Install Prometheus with cadvisor CI step to prevent a race condition that caused intermittent workflow failures.


The Install Prometheus with cadvisor step in the CI workflow intermittently fails with:

> resource mapping not found for name: "..." namespace: "monitoring" from "...serviceMonitor.yaml":
> no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
> ensure CRDs are installed first

## Summary by Sourcery

CI:
- Wait for Prometheus custom resource definitions to reach Established condition in the CI job before installing Prometheus manifests to avoid race conditions.