### PR TITLE
Add dependabot for updating Go modules, GitHub Actions, and Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "mvp_demo"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "mvp_demo"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "mvp_demo"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       - "go"
     commit-message:
       prefix: "chore(deps)"
+    open-pull-requests-limit: 10
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -23,6 +24,7 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+    open-pull-requests-limit: 5
 
   # Docker base images
   - package-ecosystem: "docker"
@@ -35,3 +37,4 @@ updates:
       - "docker"
     commit-message:
       prefix: "chore(docker)"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates across three ecosystems, all targeting the `mvp_demo` branch.

## Changes

- **Go modules** (`chore(deps)`) — weekly updates for all dependencies in `go.mod`
- **GitHub Actions** (`chore(ci)`) — weekly updates for `uses:` action versions in `.github/workflows/`
- **Docker** (`chore(docker)`) — weekly updates for base image tags in `Dockerfile` and `bundle.Dockerfile`

## Summary by Sourcery

Build:
- Configure Dependabot to manage Go module, GitHub Actions, and Docker base image dependency updates with labeled, prefixed commits targeting the mvp_demo branch.