### PR TITLE
fix: support running unit tests without make test

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.26.4'  # must match toolchain directive in go.mod
   # Must match ENVTEST_K8S_VERSION in Makefile and envtestK8sVersion in
   # internal/controller/suite_test.go.
   ENVTEST_K8S_VERSION: '1.31.0'
@@ -39,14 +39,11 @@ jobs:
       - name: Install setup-envtest
         run: make envtest
 
-      - name: Download envtest binaries
-        run: |
-          ./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} \
-            --bin-dir "$(pwd)/bin"
-
       - name: Run unit tests
         run: |
-          KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} --bin-dir "$(pwd)/bin" -p path)" \
+          BIN_DIR="$(pwd)/bin"
+          KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} --bin-dir "$BIN_DIR" -p path)"
+          export KUBEBUILDER_ASSETS
           go test ./internal/... -v -coverprofile=cover.out 2>&1 | tee /tmp/unit-test-output.log
           exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -44,7 +44,9 @@ jobs:
           BIN_DIR="$(pwd)/bin"
           KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} --bin-dir "$BIN_DIR" -p path)"
           export KUBEBUILDER_ASSETS
-          go test ./internal/... -v -coverprofile=cover.out 2>&1 | tee /tmp/unit-test-output.log
+          go test ./internal/... -v -coverprofile=cover.out 2>&1 \
+            | sed -r 's/\x1b\[[0-9;]*[mGKHF]//g' \
+            | tee unit-test-output.log
           exit ${PIPESTATUS[0]}
 
       - name: Upload unit test results
@@ -54,7 +56,7 @@ jobs:
           name: unit-test-results-pr-${{ github.event.pull_request.number }}
           path: |
             cover.out
-            /tmp/unit-test-output.log
+            unit-test-output.log
           retention-days: 7
 
   # ── Job 2: E2E tests ─────────────────────────────────────────────────────────

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -9,14 +9,65 @@ on:
 
 env:
   GO_VERSION: '1.25.9'
+  # Must match ENVTEST_K8S_VERSION in Makefile and envtestK8sVersion in
+  # internal/controller/suite_test.go.
+  ENVTEST_K8S_VERSION: '1.31.0'
   OPERATOR_IMAGE: quay.io/kruize/kruize-operator:pr-${{ github.event.pull_request.number }}
   NAMESPACE: monitoring
 
 jobs:
+  # ── Job 1: Unit tests ────────────────────────────────────────────────────────
+  # Fast gate (~1 min). No cluster, no Docker. Runs before E2E so broken logic
+  # is caught immediately without waiting for the full cluster setup.
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download && go mod verify
+
+      - name: Install setup-envtest
+        run: make envtest
+
+      - name: Download envtest binaries
+        run: |
+          ./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} \
+            --bin-dir "$(pwd)/bin"
+
+      - name: Run unit tests
+        run: |
+          KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use ${{ env.ENVTEST_K8S_VERSION }} --bin-dir "$(pwd)/bin" -p path)" \
+          go test ./internal/... -v -coverprofile=cover.out 2>&1 | tee /tmp/unit-test-output.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results-pr-${{ github.event.pull_request.number }}
+          path: |
+            cover.out
+            /tmp/unit-test-output.log
+          retention-days: 7
+
+  # ── Job 2: E2E tests ─────────────────────────────────────────────────────────
+  # Slow gate (~15 min). Requires Kind cluster + Docker image build. Only runs
+  # after unit tests pass so cluster time is not wasted on broken code.
   build-and-test:
     name: Build and Test Operator
     runs-on: ubuntu-latest
-    
+    needs: unit-test
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ OPERATOR_SDK_VERSION ?= v1.42.3
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# Must match the envtestK8sVersion constant in internal/controller/suite_test.go.
 ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/internal/controller/kruize_controller.go
+++ b/internal/controller/kruize_controller.go
@@ -124,7 +124,9 @@ func (r *KruizeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	fmt.Println("kruize object base: ", kruize.Spec)
+	logger.V(1).Info("reconciling kruize object",
+		"cluster_type", kruize.Spec.Cluster_type,
+		"namespace", kruize.Spec.Namespace)
 
 	// Validate cluster type early, before adding finalizer
 	// This ensures invalid configurations are rejected immediately
@@ -167,7 +169,7 @@ func (r *KruizeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
-	fmt.Println("Deployment initiated, waiting for pods to be ready")
+	logger.Info("Deployment initiated, waiting for pods to be ready")
 
 	var targetNamespace = kruize.Spec.Namespace
 
@@ -358,8 +360,7 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 				continue
 			}
 
-			logger.Info("Pod status check", "ready", readyPods, "total", totalPods, "namespace", namespace)
-			fmt.Printf("Pod status: %v\n", podStatus)
+			logger.V(1).Info("Pod status check", "ready", readyPods, "total", totalPods, "namespace", namespace, "status", podStatus)
 
 			// Check if we have all required pods running (kruize, kruize-ui-nginx, kruize-db, kruize-optimizer)
 			if readyPods >= 4 && totalPods >= 4 {
@@ -373,6 +374,7 @@ func (r *KruizeReconciler) waitForKruizePods(ctx context.Context, namespace stri
 }
 
 func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace string) (int, int, map[string]string, error) {
+	logger := log.FromContext(ctx)
 	podList := &corev1.PodList{}
 	err := r.Client.List(ctx, podList, client.InNamespace(namespace))
 	if err != nil {
@@ -396,7 +398,7 @@ func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace 
 	readyCount := 0
 	for _, pod := range kruizePods {
 		podStatus[pod.Name] = string(pod.Status.Phase)
-		fmt.Printf("Pod %s status: %s\n", pod.Name, pod.Status.Phase)
+		logger.V(1).Info("Pod phase", "pod", pod.Name, "phase", pod.Status.Phase)
 
 		// Check if pod is ready
 		if pod.Status.Phase == corev1.PodRunning {
@@ -404,7 +406,7 @@ func (r *KruizeReconciler) checkKruizePodsStatus(ctx context.Context, namespace 
 			for _, condition := range pod.Status.Conditions {
 				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 					readyCount++
-					fmt.Printf("Pod %s is ready\n", pod.Name)
+					logger.V(1).Info("Pod is ready", "pod", pod.Name)
 					break
 				}
 			}
@@ -571,7 +573,8 @@ func (r *KruizeReconciler) reconcileNamespacedResource(ctx context.Context, owne
 }
 
 func (r *KruizeReconciler) applyYAMLString(ctx context.Context, yamlContent string, namespace string) error {
-	fmt.Printf("Applying YAML content (size: %d bytes) to namespace: %s\n", len(yamlContent), namespace)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Applying YAML content", "size", len(yamlContent), "namespace", namespace)
 
 	docs := strings.Split(yamlContent, "---")
 
@@ -579,7 +582,7 @@ func (r *KruizeReconciler) applyYAMLString(ctx context.Context, yamlContent stri
 	if namespace != "" {
 		err := r.ensureNamespace(ctx, namespace)
 		if err != nil {
-			fmt.Printf("Warning: failed to ensure namespace %s: %v\n", namespace, err)
+			logger.Error(err, "Warning: failed to ensure namespace", "namespace", namespace)
 		}
 	}
 
@@ -594,7 +597,7 @@ func (r *KruizeReconciler) applyYAMLString(ctx context.Context, yamlContent stri
 		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 		_, _, err := dec.Decode([]byte(doc), nil, obj)
 		if err != nil {
-			fmt.Printf("Warning: failed to decode YAML document %d: %v\n", i, err)
+			logger.Error(err, "Warning: failed to decode YAML document", "index", i)
 			failCount++
 			continue
 		}
@@ -612,21 +615,21 @@ func (r *KruizeReconciler) applyYAMLString(ctx context.Context, yamlContent stri
 		})
 
 		if err != nil {
-			fmt.Printf("Warning: failed to apply %s/%s: %v\n", obj.GetKind(), obj.GetName(), err)
+			logger.Error(err, "Warning: failed to apply resource", "kind", obj.GetKind(), "name", obj.GetName())
 			failCount++
 		} else {
-			fmt.Printf("Successfully applied %s/%s\n", obj.GetKind(), obj.GetName())
+			logger.V(1).Info("Successfully applied resource", "kind", obj.GetKind(), "name", obj.GetName())
 			successCount++
 		}
 	}
 
-	fmt.Printf("Applied %d resources successfully, %d failed\n", successCount, failCount)
+	logger.V(1).Info("YAML apply complete", "success", successCount, "failed", failCount)
 	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KruizeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	fmt.Println("Setting up the controller with the Manager")
+	log.Log.Info("Setting up the controller with the Manager")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kruizev1alpha1.Kruize{}).
 		Complete(r)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -75,10 +75,12 @@ var _ = BeforeSuite(func() {
 	}
 	if binaryAssetsDir == "" {
 		systemDir, err := envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-		if err == nil {
-			binaryAssetsDir = filepath.Join(systemDir,
-				fmt.Sprintf("%s-%s-%s", envtestK8sVersion, runtime.GOOS, runtime.GOARCH))
-		}
+		Expect(err).NotTo(HaveOccurred(),
+			"failed to resolve envtest system cache directory; "+
+				"run `make test` once to download envtest binaries for Kubernetes %s",
+			envtestK8sVersion)
+		binaryAssetsDir = filepath.Join(systemDir,
+			fmt.Sprintf("%s-%s-%s", envtestK8sVersion, runtime.GOOS, runtime.GOARCH))
 	}
 
 	testEnv = &envtest.Environment{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -42,6 +43,10 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+// envtestK8sVersion is the Kubernetes control plane version whose binaries
+// setup-envtest downloads. Must match ENVTEST_K8S_VERSION in the Makefile.
+const envtestK8sVersion = "1.31.0"
+
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
@@ -56,17 +61,30 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
+
+	// Lookup order: KUBEBUILDER_ASSETS env var → project-local bin/k8s/ → setup-envtest system cache.
+	binaryAssetsDir := os.Getenv("KUBEBUILDER_ASSETS")
+	if binaryAssetsDir == "" {
+		pkgDir, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred(), "could not determine working directory")
+		localDir := filepath.Join(pkgDir, "..", "..", "bin", "k8s",
+			fmt.Sprintf("%s-%s-%s", envtestK8sVersion, runtime.GOOS, runtime.GOARCH))
+		if _, err := os.Stat(localDir); err == nil {
+			binaryAssetsDir = localDir
+		}
+	}
+	if binaryAssetsDir == "" {
+		systemDir, err := envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
+		if err == nil {
+			binaryAssetsDir = filepath.Join(systemDir,
+				fmt.Sprintf("%s-%s-%s", envtestK8sVersion, runtime.GOOS, runtime.GOARCH))
+		}
+	}
+
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: binaryAssetsDir,
 	}
 
 	var err error

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -76,12 +76,22 @@ var _ = BeforeSuite(func() {
 	if binaryAssetsDir == "" {
 		systemDir, err := envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
 		Expect(err).NotTo(HaveOccurred(),
-			"failed to resolve envtest system cache directory; "+
-				"run `make test` once to download envtest binaries for Kubernetes %s",
+			"failed to resolve envtest binary assets directory from system cache; "+
+				"run `make test` once to download envtest binaries for Kubernetes %s, "+
+				"or set KUBEBUILDER_ASSETS to the directory containing etcd and kube-apiserver",
 			envtestK8sVersion)
 		binaryAssetsDir = filepath.Join(systemDir,
 			fmt.Sprintf("%s-%s-%s", envtestK8sVersion, runtime.GOOS, runtime.GOARCH))
 	}
+
+	// Fail fast with a clear message if the resolved directory does not exist on disk.
+	// Without this, testEnv.Start() would fail with a vague "fork/exec etcd: no such file" error.
+	_, statErr := os.Stat(binaryAssetsDir)
+	Expect(statErr).NotTo(HaveOccurred(),
+		"envtest binary assets directory not found at %s; "+
+			"run `make test` once to download envtest binaries for Kubernetes %s, "+
+			"or set KUBEBUILDER_ASSETS to the directory containing etcd and kube-apiserver",
+		binaryAssetsDir, envtestK8sVersion)
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},

--- a/test/Operator_tests.md
+++ b/test/Operator_tests.md
@@ -42,7 +42,7 @@ We use [Ginkgo](https://onsi.github.io/ginkgo/) (BDD-style testing framework) an
 
 **Purpose**: Validate complete operator deployment and Kruize functionality on real Kubernetes clusters
 
-**Documentation**: See [`e2e_tests_readme.md`](../e2e_test.md) for comprehensive e2e test documentation
+**Documentation**: See [`e2e_test.md`](e2e/e2e_test.md) for comprehensive e2e test documentation
 
 **Quick Start**:
 ```bash
@@ -58,8 +58,6 @@ go test ./test/e2e/... -v -- -cluster-type=minikube
 **Location**: `internal/controller/`
 
 **Purpose**: Test individual functions and methods in isolation
-
-**Documentation**: See [`Test_readme.md`](../Operator_tests.md) for unit test documentation
 
 **Quick Start**:
 ```bash
@@ -78,66 +76,45 @@ The controller tests use [envtest](https://book.kubebuilder.io/reference/envtest
 real `etcd` and `kube-apiserver` process locally. Those binaries **must be downloaded once** before
 `go test` can succeed.
 
-#### Option A — `make test` (fully automated, recommended for CI)
+#### Option A — `make test` (recommended — handles everything)
 
-`make test` handles everything: code generation, formatting, vetting, binary download, and test execution.
+`make test` is the single entry point that does it all in the right order:
+code generation → formatting → vetting → download `setup-envtest` tool →
+download `etcd`+`kube-apiserver` binaries → run tests.
 
 ```bash
 make test
 ```
 
-No manual setup required — use this for a clean first run or in CI pipelines.
+Run this once on a fresh clone. After it completes, `bin/k8s/1.31.0-<os>-<arch>/`
+exists and `go test` works directly from then on.
 
-#### Option B — `go test` directly (faster iteration during development)
+#### Option B — `go test` directly (after Option A has run once)
 
-**Step 1 — Install `setup-envtest`** (only needed once per clone):
-
-```bash
-make envtest
-```
-
-This downloads and installs the `setup-envtest` tool itself into `bin/setup-envtest-release-0.19`.
-It does **not** download `etcd` or `kube-apiserver` — that happens in step 2.
-
-**Step 2 — Export the assets path and run tests:**
+Once `make test` has populated `bin/k8s/`, the suite resolves the binary path
+automatically via `os.Getwd()` — no env var needed:
 
 ```bash
-# ENVTEST_K8S_VERSION is defined in the Makefile (currently 1.31.0)
-export KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use $(grep 'ENVTEST_K8S_VERSION' Makefile | head -1 | awk '{print $3}') --bin-dir "$(pwd)/bin" -p path)"
 go test ./internal/controller/... -v
 ```
 
-Or with the version written out explicitly (check `ENVTEST_K8S_VERSION` in [`Makefile:56`](../Makefile) if this ever changes):
-
-```bash
-export KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use 1.31.0 --bin-dir "$(pwd)/bin" -p path)"
-go test ./internal/controller/... -v
-```
-
-The `setup-envtest use` command downloads `etcd` and `kube-apiserver` for that specific Kubernetes version
-into `bin/k8s/1.31.0-<os>-<arch>/` on first run and reuses the cached binaries on subsequent runs.
-Only step 1 ever needs to be repeated (on a fresh clone).
+> **Why does this work without `KUBEBUILDER_ASSETS`?**
+> The suite checks `KUBEBUILDER_ASSETS` first, then falls back to the absolute
+> path `<repo>/bin/k8s/1.31.0-<os>-<arch>/` using `os.Getwd()`. As long as
+> `bin/k8s/` was populated by a prior `make test`, `go test` finds the binaries
+> with no extra setup.
 
 > **What is `1.31.0`?**
-> It is the Kubernetes control plane version whose test binaries are downloaded.
-> `setup-envtest` fetches the matching `etcd` and `kube-apiserver` builds from
-> `storage.googleapis.com/kubebuilder-tools` so the test suite can spin up a real
-> (but lightweight) API server in-process. The version is pinned in the Makefile as
-> `ENVTEST_K8S_VERSION = 1.31.0` and must match the fallback path hardcoded in
-> [`suite_test.go`](../internal/controller/suite_test.go).
-
-> **Why `KUBEBUILDER_ASSETS`?**
-> The test suite reads this env var first. If it is unset, it falls back to
-> `bin/k8s/1.31.0-<goos>-<goarch>/` — the same directory `setup-envtest` writes to.
-> Setting the env var explicitly is the safest approach as it works regardless of
-> working directory.
+> The Kubernetes control plane version whose `etcd` and `kube-apiserver` binaries
+> are downloaded. Pinned as `ENVTEST_K8S_VERSION` in the Makefile and mirrored as
+> `envtestK8sVersion` in [`suite_test.go`](../internal/controller/suite_test.go).
 
 #### What each step does
 
 | Step | Command | Purpose |
 |------|---------|---------|
-| Install tool | `make envtest` | Downloads and installs the `setup-envtest` CLI into `bin/` |
-| Export + run | `export KUBEBUILDER_ASSETS=…` | `setup-envtest use` downloads `etcd`+`kube-apiserver` on first run (cached after); `-p path` prints their location into the env var; `go test` then uses it |
+| First-time setup | `make test` | Installs `setup-envtest`, downloads K8s binaries, runs all tests |
+| Subsequent runs | `go test ./internal/controller/... -v` | Uses cached binaries directly, no env var needed |
 
 ### Basic Commands
 

--- a/test/Operator_tests.md
+++ b/test/Operator_tests.md
@@ -69,12 +69,80 @@ go test ./internal/controller/... -v
 # Run with coverage
 go test ./internal/controller/... -v -coverprofile=coverage.out
 ```
+
 ## Running Unit Tests
+
+### Prerequisites
+
+The controller tests use [envtest](https://book.kubebuilder.io/reference/envtest.html), which starts a
+real `etcd` and `kube-apiserver` process locally. Those binaries **must be downloaded once** before
+`go test` can succeed.
+
+#### Option A — `make test` (fully automated, recommended for CI)
+
+`make test` handles everything: code generation, formatting, vetting, binary download, and test execution.
+
+```bash
+make test
+```
+
+No manual setup required — use this for a clean first run or in CI pipelines.
+
+#### Option B — `go test` directly (faster iteration during development)
+
+**Step 1 — Install `setup-envtest`** (only needed once per clone):
+
+```bash
+make envtest
+```
+
+This downloads and installs the `setup-envtest` tool itself into `bin/setup-envtest-release-0.19`.
+It does **not** download `etcd` or `kube-apiserver` — that happens in step 2.
+
+**Step 2 — Export the assets path and run tests:**
+
+```bash
+# ENVTEST_K8S_VERSION is defined in the Makefile (currently 1.31.0)
+export KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use $(grep 'ENVTEST_K8S_VERSION' Makefile | head -1 | awk '{print $3}') --bin-dir "$(pwd)/bin" -p path)"
+go test ./internal/controller/... -v
+```
+
+Or with the version written out explicitly (check `ENVTEST_K8S_VERSION` in [`Makefile:56`](../Makefile) if this ever changes):
+
+```bash
+export KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use 1.31.0 --bin-dir "$(pwd)/bin" -p path)"
+go test ./internal/controller/... -v
+```
+
+The `setup-envtest use` command downloads `etcd` and `kube-apiserver` for that specific Kubernetes version
+into `bin/k8s/1.31.0-<os>-<arch>/` on first run and reuses the cached binaries on subsequent runs.
+Only step 1 ever needs to be repeated (on a fresh clone).
+
+> **What is `1.31.0`?**
+> It is the Kubernetes control plane version whose test binaries are downloaded.
+> `setup-envtest` fetches the matching `etcd` and `kube-apiserver` builds from
+> `storage.googleapis.com/kubebuilder-tools` so the test suite can spin up a real
+> (but lightweight) API server in-process. The version is pinned in the Makefile as
+> `ENVTEST_K8S_VERSION = 1.31.0` and must match the fallback path hardcoded in
+> [`suite_test.go`](../internal/controller/suite_test.go).
+
+> **Why `KUBEBUILDER_ASSETS`?**
+> The test suite reads this env var first. If it is unset, it falls back to
+> `bin/k8s/1.31.0-<goos>-<goarch>/` — the same directory `setup-envtest` writes to.
+> Setting the env var explicitly is the safest approach as it works regardless of
+> working directory.
+
+#### What each step does
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| Install tool | `make envtest` | Downloads and installs the `setup-envtest` CLI into `bin/` |
+| Export + run | `export KUBEBUILDER_ASSETS=…` | `setup-envtest use` downloads `etcd`+`kube-apiserver` on first run (cached after); `-p path` prints their location into the env var; `go test` then uses it |
 
 ### Basic Commands
 
 ```bash
-# Run all unit tests
+# Run all unit tests (after setup above)
 go test ./internal/controller/... -v
 
 # Run with coverage
@@ -83,10 +151,10 @@ go test ./internal/controller/... -v -coverprofile=coverage.out
 # View coverage report
 go tool cover -html=coverage.out
 
-# Run specific test
+# Run a specific test by name
 go test ./internal/controller/... -v -ginkgo.focus="should generate RBAC"
 
-# Run tests matching pattern
+# Run tests matching a pattern
 go test ./internal/controller/... -v -ginkgo.focus="OpenShift"
 ```
 


### PR DESCRIPTION
## Summary

Unit tests (`go test ./internal/controller/...`)  failed when run directly, even after the envtest binaries had been downloaded. Only `make test` worked.

## Changes

### `internal/controller/suite_test.go`
- Read `KUBEBUILDER_ASSETS` first (set automatically by `make test`)
- Fall back to absolute project-local `bin/k8s/` path via `os.Getwd()`
- Second fallback to `envtest.SetupEnvtestDefaultBinaryAssetsDirectory()` (system cache)
- Extracted `"1.31.0"` into `const envtestK8sVersion` — single source of truth,
  cross-referenced to `ENVTEST_K8S_VERSION` in the Makefile

### `Makefile`
- Added comment on `ENVTEST_K8S_VERSION` pointing at `suite_test.go` to prevent
  silent version drift when upgrading Kubernetes

### `.github/workflows/pr-check.yaml`
- Added `unit-test` job (~1 min, no cluster, no Docker)
- `build-and-test` (E2E, ~15 min) now depends on `unit-test` via `needs:`
  so cluster time is not spent on PRs with broken unit tests

### `test/Operator_tests.md`
- Documented the setup steps for running `go test` directly
- Explained what `make envtest` installs vs what downloads the assets
- Explained what `KUBEBUILDER_ASSETS` and `1.31.0` mean

## How to verify

```bash
# One-time setup per clone
make envtest

# Direct go test — now works without any env var export
go test ./internal/controller/... -v
```

## Summary by Sourcery

Ensure envtest-based Go unit tests run consistently both via `make test` and direct `go test`, and gate E2E CI runs on fast unit tests.

Bug Fixes:
- Fix failure of controller unit tests when running `go test` directly by improving envtest binary discovery.

Enhancements:
- Align envtest Kubernetes version configuration between Go tests, Makefile, and CI via a shared constant and comments.
- Improve envtest binary lookup by preferring `KUBEBUILDER_ASSETS`, then local project cache, then the system cache.

CI:
- Add a dedicated unit-test GitHub Actions job that installs envtest assets, runs Go unit tests with coverage, and uploads results.
- Make the slower build-and-test (E2E) CI job depend on successful unit tests to avoid wasting cluster resources.

Documentation:
- Expand operator testing documentation with detailed instructions for installing envtest, running unit tests directly with `go test`, and explaining `KUBEBUILDER_ASSETS` and the pinned Kubernetes version.